### PR TITLE
cleanup of link between energy and economy

### DIFF
--- a/FRIDA.stmx
+++ b/FRIDA.stmx
@@ -5,7 +5,7 @@
 		<name>FRIDA</name>
 		<uuid>fe807591-4e3d-4e2c-b464-70ec4fb12094</uuid>
 		<vendor>isee systems, inc.</vendor>
-		<product version="3.7.2" isee:build_number="3414" isee:saved_by_v1="true" lang="en">Stella Architect</product>
+		<product version="3.7.2" isee:build_number="3414" isee:saved_by_v1="true" lang="en">Stella_Architect</product>
 	</header>
 	<sim_specs isee:sim_duration="0" isee:run_prefix="Run" isee:simulation_delay="0" isee:restore_on_start="false" isee:save_interval="1" method="RK4" time_units="Year" isee:instantaneous_flows="false" isee:ignore_module_errors="false" isee:strict_units="false" isee:loop_scores="false" isee:loop_exhaustive_allowed="1000">
 		<start>1980</start>
@@ -1479,25 +1479,11 @@
 			<eqn/>
 			<alias>K</alias>
 		</unit>
-		<unit name="G">
-			<eqn>Giga</eqn>
-		</unit>
-		<unit name="GtCO2">
-			<eqn>Giga*tCO2</eqn>
-		</unit>
-		<unit name="GtCH4">
-			<eqn>Giga*tCH4</eqn>
-		</unit>
-		<unit name="GtN2O">
-			<eqn>Giga*tN2O</eqn>
-		</unit>
 	</model_units>
 	<model>
 		<variables>
 			<module name="Energy" isee:label="" url="r../FRIDA_Modules/Energy.itmx">
 				<format scale_by="auto"/>
-				<connect to="Finance.share_of_GDP_invested_in_Energy_1" from="Energy.share_of_GDP_invested_in_Energy"/>
-				<connect2 to="Finance.share_of_GDP_invested_in_Energy_1" from="Energy.share_of_GDP_invested_in_Energy"/>
 				<connect to="Energy.biofuels_CO2e_emissions_tax_reduction_share" from="Government_Regulations.biofuels_CO2e_emissions_tax_reduction_share"/>
 				<connect2 to="Energy.biofuels_CO2e_emissions_tax_reduction_share" from="Government_Regulations.biofuels_CO2e_emissions_tax_reduction_share"/>
 				<connect to="Energy.biofuels_SO2_emissions_tax_reduction_share" from="Government_Regulations.biofuels_SO2_emissions_tax_reduction_share"/>
@@ -1542,8 +1528,8 @@
 				<connect2 to="energy_demand.today" from="Climate.today"/>
 				<connect to="Finance.All_Energy_Investments" from="energy_investments.All_Gross_Energy_Investments"/>
 				<connect2 to="Finance.All_Energy_Investments" from="energy_investments.All_Gross_Energy_Investments"/>
-				<connect to="Inflation.average_marginal_cost_of_energy" from="energy_investments.average_marginal_cost_of_energy"/>
-				<connect2 to="Inflation.average_marginal_cost_of_energy" from="energy_investments.average_marginal_cost_of_energy"/>
+				<connect to="Inflation.average_marginal_cost_of_energy" from="energy_investments.average_marginal_net_cost_of_energy"/>
+				<connect2 to="Inflation.average_marginal_cost_of_energy" from="energy_investments.average_marginal_net_cost_of_energy"/>
 				<connect to='Finance."2017b$_to_2017$"' from='energy_investments."B$_to_$"'/>
 				<connect2 to='Finance."2017b$_to_2017$"' from='energy_investments."B$_to_$"'/>
 				<connect to="Government.Coal_Investments_in_Fossil_Energy_Capital" from="energy_investments.Coal_Gross_Investments_in_Fossil_Energy_Capital"/>
@@ -1790,8 +1776,6 @@
 				<connect2 to="wind_and_solar_energy.start_year" from="Government_Regulations.start_year"/>
 				<connect to="wind_and_solar_energy.subsidy_for_newly_installed_solar_and_wind_energy_capacity" from="Government_Regulations.tax_for_newly_installed_solar_and_wind_energy_capacity"/>
 				<connect2 to="wind_and_solar_energy.subsidy_for_newly_installed_solar_and_wind_energy_capacity" from="Government_Regulations.tax_for_newly_installed_solar_and_wind_energy_capacity"/>
-				<connect to="Finance.Energy_Balance" from="energy_supply_vs_demand.Energy_Balance"/>
-				<connect2 to="Finance.Energy_Balance" from="energy_supply_vs_demand.Energy_Balance"/>
 			</module>
 			<isee:placeholder name="Calibrated Variables">
 				<eqn>Demographics.real_GDP_per_person[1] + Demographics.nominal_GDP_per_person[1] + GDP.&quot;Real_GDP_in_2021$&quot;[1] + GDP.Nominal_GDP[1] + Government.government_consumption[1] + Finance.total_investment[1] + Circular_Flow.private_consumption[1] + Employment.Wage_Rate[1] + Employment.Employed[1] + Employment.Unemployed[1] + Employment.unemployment_rate[1] + Inflation.Inflation_Rate[1] + Inflation.Inflation_Index[1] + Employment.Productivity[1] + Circular_Flow.income_inequality[1] + Employment.share_of_employment_in_agriculture[1] + Employment.share_of_employment_in_industry[1] + Employment.share_of_employment_in_services[1] + Inflation.agriculture_percentage_of_GDP[1] + Employment.share_of_employment_in_agriculture[1] + Employment.share_of_employment_in_industry[1] + Employment.share_of_employment_in_services[1] + Demographics.Aged_0_years[1] + Demographics.Aged_1_to_20_years[1] + Demographics.Aged_20_to_40_years[1] + Demographics.Aged_40_to_60_years[1] + Demographics.Aged_60_to_65_years[1] + Demographics.Aged_65_to_75_years[1] + Demographics.Aged_Over_75_years[1] + Demographics.deaths_0_years[1] + Demographics.deaths_1_to_20_years[1] + Demographics.deaths_20_to_40_years[1] + Demographics.deaths_40_to_60_years[1] + Demographics.deaths_60_to_65_years[1] + Demographics.deaths_65_to_75_years[1] + Demographics.deaths_Over_75_years[1] + Demographics.Population[1] + Demographics.fertility[1] + Demographics.Births[1] + Demographics.total_deaths[1] + Demographics.female_population_literacy_percentage[1] + Energy_Balance_Model.Surface_Temperature_Anomaly[1] + CO2_Forcing.CO2_Effective_Radiative_Forcing[1] + CH4_Forcing.CH4_Effective_Radiative_Forcing[1] + N2O_Forcing.N2O_Effective_Radiative_Forcing[1] + CO2_Forcing.Atmospheric_CO2_Concentration[1] + N2O_Forcing.Atmospheric_N2O_Concentration[1] + CH4_Forcing.Atmospheric_CH4_Concentration[1] + Emissions.Total_CH4_Emissions[1] + Emissions.Total_CO2_Emissions[1] + Emissions.Total_SO2_Emissions[1] + Emissions.Total_N2O_Emissions[1] + Emissions.N2O_Emissions_from_Food_and_Land_Use[1] + Emissions.CO2_emissions_from_Food_and_Land_Use[1] + Emissions.CH4_Emissions_from_Food_and_Land_Use[1] + Emissions.SO2_Emissions_from_Food_and_Land_Use[1] + Emissions.CO2_emissions_from_Energy[1] + Emissions.CH4_emissions_from_Energy[1] + Emissions.N2O_emissions_from_Energy[1] + Emissions.SO2_emissions_from_Energy[1] + Emissions.N2O_emissions_from_Other[1] + Emissions.CO2_Emissions_from_Other[1] + Emissions.CH4_emissions_from_Other[1] + Emissions.NOx_AFOLU_emissions[1] + Emissions.NOx_non_AFOLU_emissions[1] + Emissions.Total_NOx_emissions[1] + Emissions.VOC_emissions[1] + Emissions.CO_emissions[1] + Emissions.HFC134a_eq_emissions[1] + Land_Use.Forest_Land[1] + Crop.crop_production[1] + Land_Use.Cropland[1] + Freshwater.total_water_withdrawal[1] + Animal_Products.animal_products_production[1] + Freshwater.fraction_of_water_withdrawal_for_agriculture[1] + Food_Demand.fraction_of_crops_for_animal_products[1] + Freshwater.available_water_supply[1] + Freshwater.irrigated_cropland[1] + Animal_Products.aquatic_animal_product_share[1] + Land_Nutrients.man_made_fertilizer_use[1] + Land_Nutrients.manure_fertilizer_use[1] + Land_Nutrients.fertilizer_use[1] + fossil_energy.Secondary_Fossil_Energy_Output[1] + fossil_energy_coal.Secondary_Fossil_Energy_Output[1] + fossil_energy_oil.Secondary_Fossil_Energy_Output[1] + fossil_energy_gas.Secondary_Fossil_Energy_Output[1] + renewable_energy.Renewable_Energy_Output[1] + wind_and_solar_energy.Wind_and_Solar_Energy_Output[1] + hydropower_energy.Hydropower_Energy_Output[1] + nuclear_energy.Nuclear_Energy_Output[1] + other_energy.Other_Energy_Output[1] + bio_fuel_energy.bio_fuel_primary_energy[1] + bio_fuel_energy.bio_fuel_secondary_energy_output[1] + energy_supply.Total_Energy_Output[1] + renewable_energy.Total_Renewable_Energy_Capacity[1] + wind_and_solar_energy.Wind_and_Solar_Energy_Capacity[1] + hydropower_energy.Hydropower_Energy_Capacity[1] + other_energy.Other_Energy_Capacity[1] + bio_fuel_energy.bio_fuel_production[1] + nuclear_energy.Nuclear_Energy_Capacity[1] + fossil_energy.Primary_Fossil_Energy_FUEL[1] + fossil_energy_coal.Primary_Fossil_Energy_FUEL[1] + fossil_energy_oil.Primary_Fossil_Energy_FUEL[1] + fossil_energy_gas.Primary_Fossil_Energy_FUEL[1] + energy_demand.demand_for_energy[1] + energy_investments.Gross_Investments_in_Fossil_Fuel_Extraction_Capital[1] + energy_investments.Coal_Gross_Investments_in_Fossil_Fuel_Extraction_Capital[1] + energy_investments.Oil_Gross_Investments_in_Fossil_Fuel_Extraction_Capital[1] + energy_investments.Gas_Gross_Investments_in_Fossil_Fuel_Extraction_Capital[1] + energy_investments.Gross_Investments_in_Fossil_Energy_Capital[1] + energy_investments.Coal_Gross_Investments_in_Fossil_Energy_Capital[1] + energy_investments.Gross_Investments_in_Fossil_Energy_Capital_oil_and_gas[1] + energy_investments.Gross_Investments_in_Renewables[1] + energy_investments.Gross_Investments_in_Hydropower_Energy_capacity[1] + energy_investments.Investments_in_Nuclear_Capacity[1] + energy_investments.Gross_Investments_in_Solar_and_Wind_Energy_Capacity[1] + energy_investments.Gross_Investments_in_Other_Capacity[1] + energy_investments.Gross_Investments_in_Biofuel_Capacity[1] + wind_and_solar_energy.Installation_Cost_of_Solar_and_Wind_capacity[1] + hydropower_energy.Hydropower_Installation_Costs[1] + nuclear_energy.Nuclear_Installation_Costs[1] + energy_investments.share_of_GDP_invested_in_fuel_extraction[1] + energy_investments.share_of_GDP_invested_in_Energy_without_fuel[1] + fossil_energy_coal.Fossil_Fuel_Extraction_Carbon[1] + fossil_energy_oil.Fossil_Fuel_Extraction_Carbon[1] + fossil_energy_gas.Fossil_Fuel_Extraction_Carbon[1] + fossil_energy.conversion_efficiency_of_fossil_fuels_to_secondary_fossil_energy[1] + fossil_energy_coal.conversion_efficiency_of_fossil_fuels_to_secondary_fossil_energy[1] + fossil_energy_oil.conversion_efficiency_of_fossil_fuels_to_secondary_fossil_energy[1] + fossil_energy_gas.conversion_efficiency_of_fossil_fuels_to_secondary_fossil_energy[1] + Sea_Level.SLR_thermosteric[1] + Sea_Level.SLR_from_mountain_glaciers[1] + Sea_Level.SLR_from_Greenland_Ice_Sheet[1] + Sea_Level.SLR_from_Antarctic_Ice_Sheet[1] + Sea_Level.SLR_from_LWS[1] + Sea_Level.global_SLR[1] + Sea_Level.Land_water_storage_from_water_impoundment[1] + Employment.share_of_employment_in_agriculture[1] + Employment.share_of_employment_in_industry[1] + Employment.share_of_employment_in_services[1] + Animal_Products_Demand.Average_Daily_Demand_Per_Capita[1] + Crop.crop_balance[1] + Animal_Products.animal_products_balance[1] + Ocean.Air_sea_co2_flux[1] + Terrestrial_carbon_balance.Terrestrial_carbon_balance[1] + Terrestrial_carbon_balance.deforestation_carbon_loss[1] + Terrestrial_carbon_balance.forest_regrowth_carbon_uptake[1] + Concrete.total_yearly_concrete_use[1] + Concrete.residential_concrete_stock_in_use[1] + Concrete.Infrastructure_concrete_stock_in_use[1] + Concrete.In_use_concrete_stock[1] + Concrete.concrete_waste_generation[1] + Concrete.new_RS_construction[1]</eqn>
@@ -2551,10 +2535,6 @@ mountain glaciers (metre)} + Sea_Level.SLR_from_Greenland_Ice_Sheet_by_PCTILE[PC
 				<connect2 to='Finance."2017b$_to_2017$"' from='energy_investments."B$_to_$"'/>
 				<connect to="Finance.All_Energy_Investments" from="energy_investments.All_Gross_Energy_Investments"/>
 				<connect2 to="Finance.All_Energy_Investments" from="energy_investments.All_Gross_Energy_Investments"/>
-				<connect to="Finance.Energy_Balance" from="energy_supply_vs_demand.Energy_Balance"/>
-				<connect2 to="Finance.Energy_Balance" from="energy_supply_vs_demand.Energy_Balance"/>
-				<connect to="Finance.share_of_GDP_invested_in_Energy_1" from="Energy.share_of_GDP_invested_in_Energy"/>
-				<connect2 to="Finance.share_of_GDP_invested_in_Energy_1" from="Energy.share_of_GDP_invested_in_Energy"/>
 				<connect to="Finance.Surface_Temperature_Anomaly" from="Energy_Balance_Model.Surface_Temperature_Anomaly"/>
 				<connect2 to="Finance.Surface_Temperature_Anomaly" from="Energy_Balance_Model.Surface_Temperature_Anomaly"/>
 				<connect to="Finance.switch_for_all_climate_damage" from="Climate.switch_for_all_climate_damage"/>
@@ -2669,8 +2649,8 @@ mountain glaciers (metre)} + Sea_Level.SLR_from_Greenland_Ice_Sheet_by_PCTILE[PC
 				<connect2 to="Inflation.animal_products_demand" from="Food_Demand.animal_products_demand"/>
 				<connect to="Inflation.animal_products_production" from="Animal_Products.animal_products_production"/>
 				<connect2 to="Inflation.animal_products_production" from="Animal_Products.animal_products_production"/>
-				<connect to="Inflation.average_marginal_cost_of_energy" from="energy_investments.average_marginal_cost_of_energy"/>
-				<connect2 to="Inflation.average_marginal_cost_of_energy" from="energy_investments.average_marginal_cost_of_energy"/>
+				<connect to="Inflation.average_marginal_cost_of_energy" from="energy_investments.average_marginal_net_cost_of_energy"/>
+				<connect2 to="Inflation.average_marginal_cost_of_energy" from="energy_investments.average_marginal_net_cost_of_energy"/>
 				<connect to="Inflation.crop_demand" from="Food_Demand.crop_demand"/>
 				<connect2 to="Inflation.crop_demand" from="Food_Demand.crop_demand"/>
 				<connect to="Inflation.crop_production" from="Crop.crop_production"/>
@@ -2750,7 +2730,7 @@ mountain glaciers (metre)} + Sea_Level.SLR_from_Greenland_Ice_Sheet_by_PCTILE[PC
 				<isee:iframe color="black" background="white" text_align="left" vertical_text_align="top" font_size="12pt" border_width="thin" border_style="solid"/>
 				<isee:financial_table color="black" background="#E0E0E0" text_align="right" font_size="12pt" hide_border="false" auto_fit="true" first_column_width="250" other_column_width="100" header_font_style="normal" header_font_weight="bold" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="14pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 			</style>
-			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="3" isee:page_rows="8" isee:scroll_x="7" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
+			<view isee:show_pages="false" background="white" page_width="1091" page_height="761" isee:page_cols="3" isee:page_rows="8" isee:scroll_x="7" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
 				<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
 					<stock color="blue" background="white" font_color="blue" font_size="11pt" label_side="top">
 						<shape type="rectangle" width="45" height="35"/>
@@ -3204,7 +3184,7 @@ Lorem ipsum dolor sit amet</text_box>
 					</style>
 					<isee:shape background="#F7F7F7" border_width="thin" border_style="none" transparent_background="false" x="0" y="0" width="1066" height="600" kind="rectangle"/>
 					<graphics_frame z_index="2" fill="none" x="12.4806" y="16.9825" width="166" height="34">
-						<image width="121" height="20" size_to_parent="false" isee:transparency="0" isee:fixed_aspect_ratio="true">/Applications/Stella Architect.app/Contents/Resources/designs/Deluxe Prev-Next Blue Green Pastel_Graphics/Your logo dark.png</image>
+						<image width="121" height="20" size_to_parent="false" isee:transparency="0" isee:fixed_aspect_ratio="true">/home/benjamin/software/UHH/Stella_Architect/.app/designs/Deluxe Prev-Next Blue Green Pastel_Graphics/Your logo dark.png</image>
 					</graphics_frame>
 				</view>
 			</isee:templates>

--- a/FRIDA_Modules/Economy.itmx
+++ b/FRIDA_Modules/Economy.itmx
@@ -5,7 +5,7 @@
 		<name>Economy</name>
 		<uuid>87c9d369-189f-4c9a-86f9-24635ff46796</uuid>
 		<vendor>isee systems, inc.</vendor>
-		<product version="3.7.2" isee:build_number="3414" isee:saved_by_v1="true" lang="en">Stella Architect</product>
+		<product version="3.7.2" isee:build_number="3414" isee:saved_by_v1="true" lang="en">Stella_Architect</product>
 	</header>
 	<sim_specs isee:sim_duration="0" isee:run_prefix="Run" isee:simulation_delay="0" isee:restore_on_start="false" isee:save_interval="1" method="RK4" time_units="Year" isee:instantaneous_flows="false" isee:ignore_module_errors="false" isee:strict_units="false" isee:loop_scores="false" isee:loop_exhaustive_allowed="1000">
 		<start>1980</start>
@@ -194,18 +194,6 @@
 		<unit name="Kelvin">
 			<eqn/>
 			<alias>K</alias>
-		</unit>
-		<unit name="G">
-			<eqn>Giga</eqn>
-		</unit>
-		<unit name="GtCO2">
-			<eqn>Giga*tCO2</eqn>
-		</unit>
-		<unit name="GtCH4">
-			<eqn>Giga*tCH4</eqn>
-		</unit>
-		<unit name="GtN2O">
-			<eqn>Giga*tN2O</eqn>
 		</unit>
 	</model_units>
 	<model name="Economy">
@@ -539,8 +527,6 @@
 				<connect2 to='Finance."2017b$_to_2017$"' from='energy_investments."B$_to_$"'/>
 				<connect to="Finance.All_Energy_Investments" from="energy_investments.All_Gross_Energy_Investments"/>
 				<connect2 to="Finance.All_Energy_Investments" from="energy_investments.All_Gross_Energy_Investments"/>
-				<connect to="Finance.Energy_Balance" from="energy_supply_vs_demand.Energy_Balance"/>
-				<connect2 to="Finance.Energy_Balance" from="energy_supply_vs_demand.Energy_Balance"/>
 				<connect to="Finance.Firms_Checking_Accounts" from="Circular_Flow.Firms_Checking_Accounts"/>
 				<connect2 to="Finance.Firms_Checking_Accounts" from="Circular_Flow.Firms_Checking_Accounts"/>
 				<connect to="Finance.Firms_Innovation_Orientation" from="Innovation.Firms_Innovation_Orientation"/>
@@ -565,8 +551,6 @@
 				<connect2 to='Finance."Real_GDP_in_2021$"' from='GDP."Real_GDP_in_2021$"'/>
 				<connect to="Finance.safe_interest" from="Government.safe_interest"/>
 				<connect2 to="Finance.safe_interest" from="Government.safe_interest"/>
-				<connect to="Finance.share_of_GDP_invested_in_Energy_1" from="Energy.share_of_GDP_invested_in_Energy"/>
-				<connect2 to="Finance.share_of_GDP_invested_in_Energy_1" from="Energy.share_of_GDP_invested_in_Energy"/>
 				<connect to="Finance.Surface_Temperature_Anomaly" from="Energy_Balance_Model.Surface_Temperature_Anomaly"/>
 				<connect2 to="Finance.Surface_Temperature_Anomaly" from="Energy_Balance_Model.Surface_Temperature_Anomaly"/>
 				<connect to="Finance.switch_for_all_climate_damage" from="Climate.switch_for_all_climate_damage"/>
@@ -601,7 +585,7 @@
 				<eqn>{Enter equation for use when not hooked up to other models}</eqn>
 				<units>b$/year</units>
 			</aux>
-			<module name="Employment" isee:label="" url="/Users/bschoenberg/code/WorldTrans/Frida/FRIDA_Modules/Employment.itmx">
+			<module name="Employment" isee:label="" url="/home/benjamin/Documents/UHH/FNU/FNK/WordTrans/FRIDA/fridaGitWD-MyFork-amain/FRIDA_Modules/Employment.itmx">
 				<format scale_by="auto"/>
 				<connect to="Circular_Flow.annual_aggregate_wages" from="Employment.annual_aggregate_wages"/>
 				<connect2 to="Circular_Flow.annual_aggregate_wages" from="Employment.annual_aggregate_wages"/>
@@ -691,8 +675,8 @@
 				<connect2 to="Inflation.animal_products_demand" from="Food_Demand.animal_products_demand"/>
 				<connect to="Inflation.animal_products_production" from="Animal_Products.animal_products_production"/>
 				<connect2 to="Inflation.animal_products_production" from="Animal_Products.animal_products_production"/>
-				<connect to="Inflation.average_marginal_cost_of_energy" from="energy_investments.average_marginal_cost_of_energy"/>
-				<connect2 to="Inflation.average_marginal_cost_of_energy" from="energy_investments.average_marginal_cost_of_energy"/>
+				<connect to="Inflation.average_marginal_cost_of_energy" from="energy_investments.average_marginal_net_cost_of_energy"/>
+				<connect2 to="Inflation.average_marginal_cost_of_energy" from="energy_investments.average_marginal_net_cost_of_energy"/>
 				<connect to="Inflation.bank_profits" from="Circular_Flow.bank_profits"/>
 				<connect2 to="Inflation.bank_profits" from="Circular_Flow.bank_profits"/>
 				<connect to="Inflation.crop_demand" from="Food_Demand.crop_demand"/>
@@ -801,7 +785,7 @@
 				<isee:iframe color="black" background="white" text_align="left" vertical_text_align="top" font_size="12pt" border_width="thin" border_style="solid"/>
 				<isee:financial_table color="black" background="#E0E0E0" text_align="right" font_size="12pt" hide_border="false" auto_fit="true" first_column_width="250" other_column_width="100" header_font_style="normal" header_font_weight="bold" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="14pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 			</style>
-			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="2" isee:page_rows="2" isee:scroll_x="180" isee:scroll_y="229" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
+			<view isee:show_pages="false" background="white" page_width="1091" page_height="761" isee:page_cols="2" isee:page_rows="2" isee:scroll_x="180" isee:scroll_y="201" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
 				<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
 					<stock color="blue" background="white" font_color="blue" font_size="12.51pt" label_side="top">
 						<shape type="rectangle" width="45" height="35"/>
@@ -2654,8 +2638,7 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 				<dimensions>
 					<dim name="Run"/>
 				</dimensions>
-				<eqn>energy_and_food_adjusted_bank_investment_growth_target+(max_change_in_bank_investment_growth_target*effect_of_gdp_growth_on_bank_investment*
-effect_of_energy_investment_vs_expectation_on_investment_growth)</eqn>
+				<eqn>reference_bank_investment_growth_rate+(max_change_in_bank_investment_growth_target*effect_of_gdp_growth_on_bank_investment)</eqn>
 				<units>dmnl/year</units>
 			</aux>
 			<aux name="max change in\nbank investment\ngrowth target">
@@ -2764,65 +2747,6 @@ effect_of_energy_investment_vs_expectation_on_investment_growth)</eqn>
 				<range min="60000" max="100000"/>
 				<units>b$</units>
 			</aux>
-			<aux name="energy and food adjusted\nbank investment\ngrowth target">
-				<dimensions>
-					<dim name="Run"/>
-				</dimensions>
-				<eqn>reference_bank_investment_growth_rate*effect_of_energy_supply_demand_balance_on_investment_growth</eqn>
-				<units>1/year</units>
-			</aux>
-			<aux name="effect of energy supply demand\nbalance on investment growth">
-				<dimensions>
-					<dim name="Run"/>
-				</dimensions>
-				<eqn>(1+sensitivity_of_effect_of_energy_supply_demand_balance_on_investment_growth*(Energy_Balance-1))*1</eqn>
-				<units>dmnl</units>
-			</aux>
-			<aux name="expectation for energy investment">
-				<dimensions>
-					<dim name="Run"/>
-				</dimensions>
-				<eqn>SMTH1(share_of_GDP_invested_in_Energy_1, 
-share_of_gdp_invested_in_energy_expectation_formation_time)</eqn>
-				<isee:delay_aux/>
-				<units>dmnl</units>
-			</aux>
-			<aux name="share of gdp invested in\nenergy expectation\nformation time">
-				<eqn>5</eqn>
-				<units>years</units>
-			</aux>
-			<aux name="effect of energy\ninvestment vs expectation\non investment growth">
-				<dimensions>
-					<dim name="Run"/>
-				</dimensions>
-				<eqn>1+sensitivity_of_investment_growth_to_energy_investment_vs_expectation*
-(share_of_GDP_invested_in_Energy_1/expectation_for_energy_investment-1)</eqn>
-				<units>dmnl</units>
-			</aux>
-			<aux name="sensitivity of\ninvestment growth\nto energy investment\nvs expectation">
-				<doc>${Calibration Parameter}
-</doc>
-				<dimensions>
-					<dim name="Run"/>
-				</dimensions>
-				<element subscript="1">
-					<eqn>-1.77394514553164</eqn>
-				</element>
-				<range min="-4" max="-0.1"/>
-				<units>dmnl</units>
-			</aux>
-			<aux name="sensitivity of effect of energy\nsupply demand balance\non investment growth">
-				<doc>${Calibration Parameter}
-</doc>
-				<dimensions>
-					<dim name="Run"/>
-				</dimensions>
-				<element subscript="1">
-					<eqn>0.589337376922665</eqn>
-				</element>
-				<range min="0.1" max="4"/>
-				<units>dmnl</units>
-			</aux>
 			<aux name="risky bank assets" access="output">
 				<dimensions>
 					<dim name="Run"/>
@@ -2874,20 +2798,6 @@ share_of_gdp_invested_in_energy_expectation_formation_time)</eqn>
 					<dim name="Run"/>
 				</dimensions>
 				<eqn>Bank_Assets/Bank_Liabilities</eqn>
-				<units>dmnl</units>
-			</aux>
-			<aux name="share of GDP invested in Energy 1" access="input">
-				<dimensions>
-					<dim name="Run"/>
-				</dimensions>
-				<eqn>{Enter equation for use when not hooked up to other models}</eqn>
-				<units>dmnl</units>
-			</aux>
-			<aux name="Energy Balance" access="input">
-				<dimensions>
-					<dim name="Run"/>
-				</dimensions>
-				<eqn>{Enter equation for use when not hooked up to other models}</eqn>
 				<units>dmnl</units>
 			</aux>
 			<aux name="switch only economy energy damage 1" access="input">
@@ -3473,7 +3383,7 @@ ELSE
 				<isee:iframe color="black" background="white" text_align="left" vertical_text_align="top" font_size="12pt" border_width="thin" border_style="solid"/>
 				<isee:financial_table color="black" background="#E0E0E0" text_align="right" font_size="12pt" hide_border="false" auto_fit="true" first_column_width="250" other_column_width="100" header_font_style="normal" header_font_weight="bold" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="14pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 			</style>
-			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="4" isee:page_rows="3" isee:scroll_x="277" isee:scroll_y="600" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
+			<view isee:show_pages="false" background="white" page_width="1091" page_height="761" isee:page_cols="4" isee:page_rows="3" isee:scroll_x="157" isee:scroll_y="600" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
 				<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
 					<stock color="blue" background="white" font_color="blue" font_size="11pt" label_side="top">
 						<shape type="rectangle" width="45" height="35"/>
@@ -3762,41 +3672,6 @@ ELSE
 				<aux label_side="right" x="1567.63" y="746.145" name="initial good loans"/>
 				<aux x="1575.96" y="1115.2" name="initial bad loans"/>
 				<aux label_side="right" x="1741.42" y="746.145" name="Initial safe assets"/>
-				<aux label_side="right" x="582.081" y="1150" name="energy and food adjusted\nbank investment\ngrowth target"/>
-				<connector uid="46" angle="89.5212">
-					<from>energy_and_food_adjusted_bank_investment_growth_target</from>
-					<to>indicated_bank_investment_growth_rate</to>
-				</connector>
-				<aux label_side="right" x="582.081" y="1210.76" name="effect of energy supply demand\nbalance on investment growth"/>
-				<connector uid="47" angle="90">
-					<from>effect_of_energy_supply_demand_balance_on_investment_growth</from>
-					<to>energy_and_food_adjusted_bank_investment_growth_target</to>
-				</connector>
-				<aux label_side="left" x="526.663" y="797.797" name="expectation for energy investment"/>
-				<aux label_side="left" x="526.663" y="733.667" name="share of gdp invested in\nenergy expectation\nformation time"/>
-				<connector uid="48" angle="270">
-					<from>share_of_gdp_invested_in_energy_expectation_formation_time</from>
-					<to>expectation_for_energy_investment</to>
-				</connector>
-				<aux label_side="right" x="584.331" y="909.207" name="effect of energy\ninvestment vs expectation\non investment growth"/>
-				<connector uid="49" angle="297.367">
-					<from>expectation_for_energy_investment</from>
-					<to>effect_of_energy_investment_vs_expectation_on_investment_growth</to>
-				</connector>
-				<aux label_side="top" x="503.581" y="909.207" name="sensitivity of\ninvestment growth\nto energy investment\nvs expectation"/>
-				<connector uid="50" angle="0">
-					<from>sensitivity_of_investment_growth_to_energy_investment_vs_expectation</from>
-					<to>effect_of_energy_investment_vs_expectation_on_investment_growth</to>
-				</connector>
-				<connector uid="51" angle="269.372">
-					<from>effect_of_energy_investment_vs_expectation_on_investment_growth</from>
-					<to>indicated_bank_investment_growth_rate</to>
-				</connector>
-				<aux label_side="left" x="554.75" y="1279.03" name="sensitivity of effect of energy\nsupply demand balance\non investment growth"/>
-				<connector uid="52" angle="68.1817">
-					<from>sensitivity_of_effect_of_energy_supply_demand_balance_on_investment_growth</from>
-					<to>effect_of_energy_supply_demand_balance_on_investment_growth</to>
-				</connector>
 				<aux label_side="right" label_angle="315" x="2642.49" y="1470.21" name="risky bank assets"/>
 				<aux label_side="right" label_angle="315" x="2641.66" y="1303.08" name="private\nsafe bank assets"/>
 				<connector uid="53" angle="345">
@@ -3843,20 +3718,6 @@ ELSE
 				<connector uid="64" angle="94.642">
 					<from>Bank_Liabilities</from>
 					<to>net_bank_assets</to>
-				</connector>
-				<aux font_style="italic" font_weight="bold" label_side="top" x="653" y="797.797" name="share of GDP invested in Energy 1"/>
-				<connector uid="67" angle="180">
-					<from>share_of_GDP_invested_in_Energy_1</from>
-					<to>expectation_for_energy_investment</to>
-				</connector>
-				<connector uid="68" angle="238.352">
-					<from>share_of_GDP_invested_in_Energy_1</from>
-					<to>effect_of_energy_investment_vs_expectation_on_investment_growth</to>
-				</connector>
-				<aux font_style="italic" font_weight="bold" label_side="right" x="605.998" y="1279.03" name="Energy Balance"/>
-				<connector uid="69" angle="109.307">
-					<from>Energy_Balance</from>
-					<to>effect_of_energy_supply_demand_balance_on_investment_growth</to>
 				</connector>
 				<aux font_style="italic" font_weight="bold" label_side="bottom" x="1706.17" y="886.587" name="switch only economy energy damage 1"/>
 				<aux font_style="italic" font_weight="bold" label_side="top" x="1706.17" y="820.377" name="switch for all climate damage"/>
@@ -4383,9 +4244,9 @@ ELSE
 					<from>reference_bank_investment_growth_rate</from>
 					<to>max_change_in_bank_investment_growth_target</to>
 				</connector>
-				<connector uid="192" angle="164.578">
+				<connector uid="193" angle="122.905">
 					<from>reference_bank_investment_growth_rate</from>
-					<to>energy_and_food_adjusted_bank_investment_growth_target</to>
+					<to>indicated_bank_investment_growth_rate</to>
 				</connector>
 				<alias label_side="right" uid="27" x="1661.17" y="996.547" width="18" height="18">
 					<of>loan_maturation_time</of>
@@ -6823,7 +6684,7 @@ agriculture_share_of_GDP_starting_point_determinant*EXP(agriculture_share_of_GDP
 				<isee:iframe color="black" background="white" text_align="left" vertical_text_align="top" font_size="12pt" border_width="thin" border_style="solid"/>
 				<isee:financial_table color="black" background="#E0E0E0" text_align="right" font_size="12pt" hide_border="false" auto_fit="true" first_column_width="250" other_column_width="100" header_font_style="normal" header_font_weight="bold" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="14pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 			</style>
-			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="3" isee:page_rows="3" isee:scroll_x="313" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
+			<view isee:show_pages="false" background="white" page_width="1091" page_height="761" isee:page_cols="3" isee:page_rows="3" isee:scroll_x="111" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
 				<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
 					<stock color="blue" background="white" font_color="blue" font_size="11pt" label_side="top">
 						<shape type="rectangle" width="45" height="35"/>

--- a/FRIDA_Modules/Energy.itmx
+++ b/FRIDA_Modules/Energy.itmx
@@ -5,7 +5,7 @@
 		<name>Energy</name>
 		<uuid>dda966fe-252b-44a1-a101-0c3526293b30</uuid>
 		<vendor>isee systems, inc.</vendor>
-		<product version="3.7.2" isee:build_number="3414" isee:saved_by_v1="true" lang="en">Stella Architect</product>
+		<product version="3.7.2" isee:build_number="3414" isee:saved_by_v1="true" lang="en">Stella_Architect</product>
 	</header>
 	<sim_specs isee:sim_duration="1.5" isee:run_prefix="Run" isee:simulation_delay="0.125" isee:restore_on_start="false" isee:save_interval="2" method="Euler" time_units="Months" isee:instantaneous_flows="false" isee:ignore_module_errors="false" isee:strict_units="false" isee:loop_scores="true" isee:loop_exhaustive_allowed="1000">
 		<start>0</start>
@@ -210,18 +210,6 @@
 		<unit name="Kelvin">
 			<eqn/>
 			<alias>K</alias>
-		</unit>
-		<unit name="G">
-			<eqn>Giga</eqn>
-		</unit>
-		<unit name="GtCO2">
-			<eqn>Giga*tCO2</eqn>
-		</unit>
-		<unit name="GtCH4">
-			<eqn>Giga*tCH4</eqn>
-		</unit>
-		<unit name="GtN2O">
-			<eqn>Giga*tN2O</eqn>
 		</unit>
 	</model_units>
 	<model name="Energy" run="true">
@@ -460,8 +448,8 @@
 				<connect2 to="adaptive_energy_investments_proportional_factor" from="energy_investments.adaptive_energy_investments_proportional_factor"/>
 				<connect to="Finance.All_Energy_Investments" from="energy_investments.All_Gross_Energy_Investments"/>
 				<connect2 to="Finance.All_Energy_Investments" from="energy_investments.All_Gross_Energy_Investments"/>
-				<connect to="Inflation.average_marginal_cost_of_energy" from="energy_investments.average_marginal_cost_of_energy"/>
-				<connect2 to="Inflation.average_marginal_cost_of_energy" from="energy_investments.average_marginal_cost_of_energy"/>
+				<connect to="Inflation.average_marginal_cost_of_energy" from="energy_investments.average_marginal_net_cost_of_energy"/>
+				<connect2 to="Inflation.average_marginal_cost_of_energy" from="energy_investments.average_marginal_net_cost_of_energy"/>
 				<connect to='Finance."2017b$_to_2017$"' from='energy_investments."B$_to_$"'/>
 				<connect2 to='Finance."2017b$_to_2017$"' from='energy_investments."B$_to_$"'/>
 				<connect to="Energy.baseline_energy_investments" from="energy_investments.baseline_energy_investments"/>
@@ -970,8 +958,6 @@
 			</module>
 			<module name="energy supply vs\ndemand" isee:label="">
 				<format scale_by="auto"/>
-				<connect to="Finance.Energy_Balance" from="energy_supply_vs_demand.Energy_Balance"/>
-				<connect2 to="Finance.Energy_Balance" from="energy_supply_vs_demand.Energy_Balance"/>
 				<connect to="Energy.energy_supply_missmatch_buffer" from="energy_supply_vs_demand.energy_supply_missmatch_buffer"/>
 				<connect2 to="energy_supply_missmatch_buffer" from="energy_supply_vs_demand.energy_supply_missmatch_buffer"/>
 				<connect to="energy_investments.Relative_Energy_Supply_Missmatch" from="energy_supply_vs_demand.Relative_Energy_Supply_Missmatch"/>
@@ -1563,7 +1549,7 @@
 				<isee:iframe color="black" background="white" text_align="left" vertical_text_align="top" font_size="12pt" border_width="thin" border_style="solid"/>
 				<isee:financial_table color="black" background="#E0E0E0" text_align="right" font_size="12pt" hide_border="false" auto_fit="true" first_column_width="250" other_column_width="100" header_font_style="normal" header_font_weight="bold" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="14pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 			</style>
-			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="12" isee:page_rows="7" isee:scroll_x="600" isee:scroll_y="300" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
+			<view isee:show_pages="false" background="white" page_width="1091" page_height="761" isee:page_cols="12" isee:page_rows="7" isee:scroll_x="600" isee:scroll_y="300" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
 				<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
 					<stock color="blue" background="white" font_color="blue" font_size="9pt" label_side="top">
 						<shape type="rectangle" width="45" height="35"/>
@@ -2290,7 +2276,7 @@ GREEN: Cost and Emissions minimal provision of energy demanded </text_box>
 							<entity name='bio_fuel_energy."Cost_of_Extra_Energy_Output_through_bio_fuel_production_capacity_per_Unit_net_of_subsidies,_taxes_and_storage_costs"[1]'/>
 						</plot>
 						<plot color="red" pen_style="dotted" isee:keep_zero_visible="true" pen_width="4" index="11" show_y_axis="true">
-							<entity name="energy_investments.average_marginal_cost_of_energy[1]"/>
+							<entity name="energy_investments.average_marginal_net_cost_of_energy[1]"/>
 						</plot>
 					</graph>
 				</stacked_container>
@@ -4713,7 +4699,7 @@ ELSE
 				<eqn>{Enter equation for use when not hooked up to other models}</eqn>
 				<units>$*Years/kWh</units>
 			</aux>
-			<aux name="average marginal cost of energy" access="output" isee:autocreated="true">
+			<aux name="average marginal net cost of energy" access="output" isee:autocreated="true">
 				<dimensions>
 					<dim name="Run"/>
 				</dimensions>
@@ -5044,7 +5030,7 @@ adjusted_cost[Run,Coal_fuel_extraction] * Coal_Gross_Investments_in_Fossil_Fuel_
 				<isee:iframe color="black" background="white" text_align="left" vertical_text_align="top" font_size="12pt" border_width="thin" border_style="solid"/>
 				<isee:financial_table color="black" background="#E0E0E0" text_align="right" font_size="12pt" hide_border="false" auto_fit="true" first_column_width="250" other_column_width="100" header_font_style="normal" header_font_weight="bold" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="14pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 			</style>
-			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="8" isee:page_rows="8" isee:scroll_x="1423.75" isee:scroll_y="375" zoom="80" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
+			<view isee:show_pages="false" background="white" page_width="1091" page_height="761" isee:page_cols="8" isee:page_rows="8" isee:scroll_x="1043.33" isee:scroll_y="955" zoom="120" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
 				<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
 					<stock color="blue" background="white" font_color="blue" font_size="11pt" label_side="top">
 						<shape type="rectangle" width="45" height="35"/>
@@ -5957,149 +5943,149 @@ https://en.wikipedia.org/wiki/Proportional%E2%80%93integral%E2%80%93derivative_c
 					<from>Cost_of_Extra_Energy_Output_through_Capital_per_Unit_7</from>
 					<to>cost_to_build_per_unit</to>
 				</connector>
-				<aux x="1711.91" y="1342.81" name="average marginal cost of energy"/>
-				<connector uid="508" angle="343.531">
+				<aux x="1885.02" y="1331.48" name="average marginal net cost of energy"/>
+				<connector uid="508" angle="345.474">
 					<from>Coal_Gross_Investments_in_Fossil_Fuel_Extraction_Capital</from>
-					<to>average_marginal_cost_of_energy</to>
+					<to>average_marginal_net_cost_of_energy</to>
 				</connector>
-				<connector uid="509" angle="339.761">
+				<connector uid="509" angle="342.405">
 					<from>Coal_Gross_Investments_in_Fossil_Energy_Capital</from>
-					<to>average_marginal_cost_of_energy</to>
+					<to>average_marginal_net_cost_of_energy</to>
 				</connector>
-				<connector uid="510" angle="335.021">
+				<connector uid="510" angle="338.88">
 					<from>Oil_Gross_Investments_in_Fossil_Fuel_Extraction_Capital</from>
-					<to>average_marginal_cost_of_energy</to>
+					<to>average_marginal_net_cost_of_energy</to>
 				</connector>
-				<connector uid="511" angle="324.412">
+				<connector uid="511" angle="330.754">
 					<from>Oil_Gross_Investments_in_Fossil_Energy_Capital</from>
-					<to>average_marginal_cost_of_energy</to>
+					<to>average_marginal_net_cost_of_energy</to>
 				</connector>
-				<connector uid="512" angle="311.935">
+				<connector uid="512" angle="322.602">
 					<from>Gas_Gross_Investments_in_Fossil_Fuel_Extraction_Capital</from>
-					<to>average_marginal_cost_of_energy</to>
+					<to>average_marginal_net_cost_of_energy</to>
 				</connector>
-				<connector uid="513" angle="284.349">
+				<connector uid="513" angle="302.374">
 					<from>Gas_Gross_Investments_in_Fossil_Energy_Capital</from>
-					<to>average_marginal_cost_of_energy</to>
+					<to>average_marginal_net_cost_of_energy</to>
 				</connector>
-				<connector uid="514" angle="261.49">
+				<connector uid="514" angle="282.99">
 					<from>Gross_Investments_in_Solar_and_Wind_Energy_Capacity</from>
-					<to>average_marginal_cost_of_energy</to>
+					<to>average_marginal_net_cost_of_energy</to>
 				</connector>
-				<connector uid="515" angle="240.424">
+				<connector uid="515" angle="258.101">
 					<from>Gross_Investments_in_Hydropower_Energy_capacity</from>
-					<to>average_marginal_cost_of_energy</to>
+					<to>average_marginal_net_cost_of_energy</to>
 				</connector>
-				<connector uid="516" angle="224.388">
+				<connector uid="516" angle="235.847">
 					<from>Gross_Investments_in_Biofuel_Capacity</from>
-					<to>average_marginal_cost_of_energy</to>
+					<to>average_marginal_net_cost_of_energy</to>
 				</connector>
-				<connector uid="517" angle="218.207">
+				<connector uid="517" angle="226.598">
 					<from>Gross_Investments_in_Other_Capacity</from>
-					<to>average_marginal_cost_of_energy</to>
+					<to>average_marginal_net_cost_of_energy</to>
 				</connector>
-				<connector uid="518" angle="209.14">
+				<connector uid="518" angle="214.295">
 					<from>Investments_in_Nuclear_Capacity</from>
-					<to>average_marginal_cost_of_energy</to>
+					<to>average_marginal_net_cost_of_energy</to>
 				</connector>
-				<connector uid="519" angle="22.4963">
+				<connector uid="519" angle="19.569">
 					<from>cost_of_extra_energy_output_through_fuel_extraction_per_unit</from>
-					<to>average_marginal_cost_of_energy</to>
+					<to>average_marginal_net_cost_of_energy</to>
 				</connector>
-				<connector uid="520" angle="26.913">
+				<connector uid="520" angle="23.4234">
 					<from>Cost_of_Extra_Energy_Output_through_Capital_per_Unit</from>
-					<to>average_marginal_cost_of_energy</to>
+					<to>average_marginal_net_cost_of_energy</to>
 				</connector>
-				<connector uid="521" angle="28.783">
+				<connector uid="521" angle="24.0843">
 					<from>cost_of_extra_energy_output_through_fuel_extraction_per_unit_2</from>
-					<to>average_marginal_cost_of_energy</to>
+					<to>average_marginal_net_cost_of_energy</to>
 				</connector>
-				<connector uid="522" angle="33.9551">
+				<connector uid="522" angle="28.5797">
 					<from>Cost_of_Extra_Energy_Output_through_Capital_per_Unit_2</from>
-					<to>average_marginal_cost_of_energy</to>
+					<to>average_marginal_net_cost_of_energy</to>
 				</connector>
-				<connector uid="523" angle="39.2054">
+				<connector uid="523" angle="31.0469">
 					<from>cost_of_extra_energy_output_through_fuel_extraction_per_unit_1</from>
-					<to>average_marginal_cost_of_energy</to>
+					<to>average_marginal_net_cost_of_energy</to>
 				</connector>
-				<connector uid="524" angle="44.996">
+				<connector uid="524" angle="36.2653">
 					<from>Cost_of_Extra_Energy_Output_through_Capital_per_Unit_1</from>
-					<to>average_marginal_cost_of_energy</to>
+					<to>average_marginal_net_cost_of_energy</to>
 				</connector>
-				<connector uid="525" angle="67.9508">
+				<connector uid="525" angle="49.1381">
 					<from>Cost_of_Extra_Energy_Output_through_Capital_per_Unit_3</from>
-					<to>average_marginal_cost_of_energy</to>
+					<to>average_marginal_net_cost_of_energy</to>
 				</connector>
-				<connector uid="526" angle="71.7094">
+				<connector uid="526" angle="54.625">
 					<from>Cost_of_Extra_Energy_Output_through_Capital_per_Unit_4</from>
-					<to>average_marginal_cost_of_energy</to>
+					<to>average_marginal_net_cost_of_energy</to>
 				</connector>
-				<connector uid="527" angle="74.4554">
+				<connector uid="527" angle="59.0396">
 					<from>Cost_of_Extra_Energy_Output_through_Capital_per_Unit_5</from>
-					<to>average_marginal_cost_of_energy</to>
+					<to>average_marginal_net_cost_of_energy</to>
 				</connector>
-				<connector uid="528" angle="76.1182">
+				<connector uid="528" angle="62.2002">
 					<from>Cost_of_Extra_Energy_Output_through_Capital_per_Unit_7</from>
-					<to>average_marginal_cost_of_energy</to>
+					<to>average_marginal_net_cost_of_energy</to>
 				</connector>
-				<connector uid="529" angle="108.966">
+				<connector uid="529" angle="82.0572">
 					<from>Cost_of_Extra_Energy_Output_through_Capital_per_Unit_6</from>
-					<to>average_marginal_cost_of_energy</to>
+					<to>average_marginal_net_cost_of_energy</to>
 				</connector>
-				<connector uid="530" angle="310.827">
+				<connector uid="530" angle="316.636">
 					<from>Total_Gross_Investments_in_Energy</from>
-					<to>average_marginal_cost_of_energy</to>
+					<to>average_marginal_net_cost_of_energy</to>
 				</connector>
-				<aux x="1874.41" y="1342.81" name="average margina adjustedl\ncost of energy"/>
-				<connector uid="532" angle="4.72225">
+				<aux x="1622.74" y="1334.98" name="average margina adjustedl\ncost of energy"/>
+				<connector uid="532" angle="21.7819">
 					<from>adjusted_cost</from>
 					<to>average_margina_adjustedl_cost_of_energy</to>
 				</connector>
-				<connector uid="533" angle="345.03">
+				<connector uid="533" angle="342.86">
 					<from>Coal_Gross_Investments_in_Fossil_Fuel_Extraction_Capital</from>
 					<to>average_margina_adjustedl_cost_of_energy</to>
 				</connector>
-				<connector uid="534" angle="348.416">
+				<connector uid="534" angle="338.71">
 					<from>Coal_Gross_Investments_in_Fossil_Energy_Capital</from>
 					<to>average_margina_adjustedl_cost_of_energy</to>
 				</connector>
-				<connector uid="535" angle="338.211">
+				<connector uid="535" angle="333.27">
 					<from>Oil_Gross_Investments_in_Fossil_Fuel_Extraction_Capital</from>
 					<to>average_margina_adjustedl_cost_of_energy</to>
 				</connector>
-				<connector uid="536" angle="329.884">
+				<connector uid="536" angle="321.064">
 					<from>Oil_Gross_Investments_in_Fossil_Energy_Capital</from>
 					<to>average_margina_adjustedl_cost_of_energy</to>
 				</connector>
-				<connector uid="537" angle="321.399">
+				<connector uid="537" angle="305.61">
 					<from>Gas_Gross_Investments_in_Fossil_Fuel_Extraction_Capital</from>
 					<to>average_margina_adjustedl_cost_of_energy</to>
 				</connector>
-				<connector uid="538" angle="300.824">
+				<connector uid="538" angle="273.998">
 					<from>Gas_Gross_Investments_in_Fossil_Energy_Capital</from>
 					<to>average_margina_adjustedl_cost_of_energy</to>
 				</connector>
-				<connector uid="539" angle="281.423">
+				<connector uid="539" angle="250.785">
 					<from>Gross_Investments_in_Solar_and_Wind_Energy_Capacity</from>
 					<to>average_margina_adjustedl_cost_of_energy</to>
 				</connector>
-				<connector uid="540" angle="257.161">
+				<connector uid="540" angle="232.532">
 					<from>Gross_Investments_in_Hydropower_Energy_capacity</from>
 					<to>average_margina_adjustedl_cost_of_energy</to>
 				</connector>
-				<connector uid="541" angle="235.609">
+				<connector uid="541" angle="219.192">
 					<from>Gross_Investments_in_Biofuel_Capacity</from>
 					<to>average_margina_adjustedl_cost_of_energy</to>
 				</connector>
-				<connector uid="542" angle="226.604">
+				<connector uid="542" angle="214.194">
 					<from>Gross_Investments_in_Other_Capacity</from>
 					<to>average_margina_adjustedl_cost_of_energy</to>
 				</connector>
-				<connector uid="543" angle="214.525">
+				<connector uid="543" angle="206.414">
 					<from>Investments_in_Nuclear_Capacity</from>
 					<to>average_margina_adjustedl_cost_of_energy</to>
 				</connector>
-				<connector uid="544" angle="315.986">
+				<connector uid="544" angle="307.832">
 					<from>Total_Gross_Investments_in_Energy</from>
 					<to>average_margina_adjustedl_cost_of_energy</to>
 				</connector>
@@ -15590,7 +15576,7 @@ ELSE
 						<pt x="428.214" y="623.571"/>
 						<pt x="248.214" y="657.071"/>
 						<pt x="77.2143" y="620.571"/>
-						<pt x="66.5507" y="556.987"/>
+						<pt x="66.551" y="556.987"/>
 					</pts>
 					<from>Installation_of_bio_Capacity</from>
 					<to>accumulating_Renewable_Energy_Construction</to>


### PR DESCRIPTION
removed the link from energy to the finance module. The effect of energy prices is captured through the new inflation mechanisms.

Renamed marginal average cost of energy to be average net marginal cost as that is what is and needs to be as input to inflation.

Martin says hi.

Changes initiated based on discussions if we should calculate shares based on net or gross investments, then realised we don't need share of investments at all for finance or inflation, only price.