### PR TITLE
Added smth to government debt interest

### DIFF
--- a/FRIDA_Modules/Economy.itmx
+++ b/FRIDA_Modules/Economy.itmx
@@ -822,7 +822,7 @@
 			<isee:placeholder name="Economy 2 Outputs">
 				<eqn>GDP.Nominal_GDP[1] + GDP.&quot;Real_GDP_in_2021c$&quot;[1] + Circular_Flow.private_consumption[1] + Government.government_consumption[1] + Finance.total_investment[1] + Employment.Employed[1] + Employment.Unemployed[1] + Employment.Wage_Rate[1] + Employment.unemployment_rate[1] + Government.debt_to_GDP_ratio[1]</eqn>
 			</isee:placeholder>
-			<module name="Sea level rise Impacts\nand Adaptation" isee:label="" url="/Users/bschoenberg/code/WorldTrans/Frida/FRIDA_Modules/Sea level rise Impacts and Adaptation.itmx">
+			<module name="Sea level rise Impacts\nand Adaptation" isee:label="" url="/Users/bschoenberg/code/WorldTrans/clones/me/WorldTransFRIDA/FRIDA_Modules/Sea level rise Impacts and Adaptation.itmx">
 				<format scale_by="auto"/>
 				<connect to="Sea_level_rise_Impacts_and_Adaptation.No_SLR_adaptation_strategy" from="Government_Regulations.No_SLR_adaptation_strategy"/>
 				<connect2 to="Sea_level_rise_Impacts_and_Adaptation.No_SLR_adaptation_strategy" from="Government_Regulations.No_SLR_adaptation_strategy"/>
@@ -7848,7 +7848,7 @@ ELSE 0</eqn>
 				<dimensions>
 					<dim name="Run"/>
 				</dimensions>
-				<eqn>Government_Debt*safe_interest</eqn>
+				<eqn>Government_Debt*average_government_debt_interest_rate</eqn>
 				<units>b$/year</units>
 			</aux>
 			<aux name="public expenditure\nfor consumption\nand transfers">
@@ -8641,6 +8641,17 @@ ELSE
 				<eqn>{Enter equation for use when not hooked up to other models}</eqn>
 				<units>year</units>
 			</aux>
+			<aux name="average government debt\ninterest rate">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>SMTH1(safe_interest, average_time_government_refinances_debt)</eqn>
+				<units>1/year</units>
+			</aux>
+			<aux name="average time government refinances debt">
+				<eqn>30</eqn>
+				<units>years</units>
+			</aux>
 		</variables>
 		<views>
 			<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
@@ -8690,7 +8701,7 @@ ELSE
 				<isee:iframe color="black" background="white" text_align="left" vertical_text_align="top" font_size="12pt" border_width="thin" border_style="solid"/>
 				<isee:financial_table color="black" background="#E0E0E0" text_align="right" font_size="12pt" hide_border="false" auto_fit="true" first_column_width="250" other_column_width="100" header_font_style="normal" header_font_weight="bold" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="14pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 			</style>
-			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="3" isee:page_rows="4" isee:scroll_x="292.143" isee:scroll_y="378.571" zoom="140" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
+			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="3" isee:page_rows="4" isee:scroll_x="292.143" isee:scroll_y="377.857" zoom="140" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
 				<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
 					<stock color="blue" background="white" font_color="blue" font_size="11pt" label_side="top">
 						<shape type="rectangle" width="45" height="35"/>
@@ -8754,12 +8765,8 @@ ELSE
 					<to>public_expenditure_for_consumption_and_transfers</to>
 				</connector>
 				<aux label_side="left" x="145.14" y="340.2" name="public\nconsumption to transfers\nratio"/>
-				<connector uid="11" angle="108.31">
-					<from>safe_interest</from>
-					<to>government_interest_payments</to>
-				</connector>
 				<aux label_side="right" x="83.429" y="38.1667" name="initial government debt"/>
-				<aux label_side="left" label_angle="135" x="589.726" y="776.759" name="safe\ninterest"/>
+				<aux label_side="left" x="618.13" y="846.759" name="safe\ninterest"/>
 				<aux label_side="left" label_angle="135" x="145.14" y="268.2" name="government\nconsumption"/>
 				<connector uid="12" angle="90">
 					<from>public_consumption_to_transfers_ratio</from>
@@ -8878,7 +8885,7 @@ ELSE
 					<from>inflation_target_discrepancy</from>
 					<to>interest_rate_policy_discrepancy</to>
 				</connector>
-				<connector uid="46" angle="67.6176">
+				<connector uid="46" angle="49.4867">
 					<from>Central_Bank_Safe_Interest</from>
 					<to>safe_interest</to>
 				</connector>
@@ -9464,6 +9471,20 @@ ELSE
 				<connector uid="228" angle="90">
 					<from>computed_government_debt_to_GDP_ratio_target</from>
 					<to>one_to_one_effect_of_debt_to_GDP_ratio_on_government_spending</to>
+				</connector>
+				<aux x="618.13" y="773.571" name="average government debt\ninterest rate"/>
+				<connector uid="229" angle="64.5202">
+					<from>safe_interest</from>
+					<to>average_government_debt_interest_rate</to>
+				</connector>
+				<connector uid="230" angle="149.419">
+					<from>average_government_debt_interest_rate</from>
+					<to>government_interest_payments</to>
+				</connector>
+				<aux x="731.714" y="785" name="average time government refinances debt"/>
+				<connector uid="231" angle="171.235">
+					<from>average_time_government_refinances_debt</from>
+					<to>average_government_debt_interest_rate</to>
 				</connector>
 				<alias font_style="italic" label_side="right" label_angle="315" uid="73" x="385.797" y="954.5" width="18" height="18">
 					<of>baseline_interest</of>


### PR DESCRIPTION
a simple proposed structure to make government interest payments not change so much in response to changes by the central bank.  I introduced  a "government debt interest rate" which is a 30 year smoothing process (the assumption being that on average governments refinance their debt after 30 years) of the safe asset interest rate which lets us avoid what I see as the unnecessary detail of vintaging government debt, but still captures the dynamics of government debt being based on a variety of loans with differning (longish) terms and therefore not responding instantenously to changes in inflation and unemployment. 