### PR TITLE
Add climate feedback which triggers more government investment in response to STA

### DIFF
--- a/FRIDA.stmx
+++ b/FRIDA.stmx
@@ -3,7 +3,7 @@
 	<header>
 		<smile version="1.0" namespace="std, isee" uses_arrays="2" uses_conveyor="" uses_submodels=""/>
 		<name>FRIDA</name>
-		<uuid>fe807591-4e3d-4e2c-b464-70ec4fb12094</uuid>
+		<uuid>dda966fe-252b-44a1-a101-0c3526293b30</uuid>
 		<vendor>isee systems, inc.</vendor>
 		<product version="3.7.3" isee:build_number="3465" isee:saved_by_v1="true" lang="en">Stella Architect</product>
 	</header>
@@ -98,7 +98,7 @@
 			<isee:variable type="adhoc" name="Finance.sensitivity_of_effect_of_sta_on_failure_rate[1]"/>
 		</isee:sensi_specs>
 	</isee:sensi_specs_list>
-	<isee:optimizer_specs_list active_index="16">
+	<isee:optimizer_specs_list active_index="14">
 		<isee:optimizer_specs name="Demographics Calibration" method="Powell" use_additional_starts_file="false" additional_starts="0" report_interval="1" confidence_range="0" maxiter="0">
 			<isee:parameter name="Demographics.infant_mortality_alpha" scaling="100000"/>
 			<isee:parameter name="Demographics.infant_mortality_gamma" scaling="100000"/>
@@ -345,7 +345,7 @@
 			<isee:parameter name="Finance.normal_failure_rate" scaling="100"/>
 			<isee:parameter name="Finance.max_change_in_failure_rate" scaling="100"/>
 			<isee:parameter name="Finance.elasticity_of_bankruptcy_rate_on_risk_premium" scaling="10"/>
-			<isee:parameter name="Government.public_consumption_to_transfers_ratio" scaling="100"/>
+			<isee:parameter name="Government.normal_public_consumption_to_transfers_ratio" scaling="100"/>
 			<isee:parameter name="Circular_Flow.wage_tax_rate" scaling="100"/>
 			<isee:parameter name="Circular_Flow.profit_tax_rate" scaling="100"/>
 			<isee:parameter name="Government.normal_investment_share_of_public_expenditure" scaling="100"/>
@@ -388,7 +388,7 @@
 			<isee:parameter name="Finance.initial_bank_investment_growth_rate" scaling="100"/>
 			<isee:parameter name="Government.averaging_time_to_adjust_tax_based_on_income" scaling="100"/>
 			<isee:parameter name="Government.maximum_effect_of_debt_to_GDP_ratio_on_government_spending" scaling="100"/>
-			<isee:parameter name="Government.sensitivity_of_effect_of_sta_on_government_investment" scaling="100"/>
+			<isee:parameter name="Government.sensitivity_of_STA_on_public_consumption" scaling="100"/>
 			<isee:parameter name="Finance.sensitivity_of_effect_of_sta_on_failure_rate[1]" scaling="100"/>
 			<isee:payoff name="Economic Payoff" action="min"/>
 		</isee:optimizer_specs>
@@ -712,37 +712,37 @@
 			</isee:payoff_element>
 		</isee:payoff_specs>
 		<isee:payoff_specs name="Economic Payoff" calibration="true" recompute_weights="true" compare_tolerance="0" compare_type="ls" compare_run="Calibration Data">
-			<isee:payoff_element name="Circular_Flow.private_consumption[1]" weight="0.00000179696">
+			<isee:payoff_element name="Circular_Flow.private_consumption[1]" weight="0.00000260743">
 				<isee:time_range type="terminal_value"/>
 			</isee:payoff_element>
-			<isee:payoff_element name="Employment.Employed[1]" weight="0.000241131">
+			<isee:payoff_element name="Employment.Employed[1]" weight="0.000239686">
 				<isee:time_range type="terminal_value"/>
 			</isee:payoff_element>
-			<isee:payoff_element name="Employment.Unemployed[1]" weight="0.00544259">
+			<isee:payoff_element name="Employment.Unemployed[1]" weight="0.00605214">
 				<isee:time_range type="terminal_value"/>
 			</isee:payoff_element>
-			<isee:payoff_element name="Employment.Wage_Rate[1]" weight="0.0000124618">
+			<isee:payoff_element name="Employment.Wage_Rate[1]" weight="0.00000700802">
 				<isee:time_range type="terminal_value"/>
 			</isee:payoff_element>
-			<isee:payoff_element name="Employment.unemployment_rate[1]" weight="23907.7">
+			<isee:payoff_element name="Employment.unemployment_rate[1]" weight="26354.3">
 				<isee:time_range type="terminal_value"/>
 			</isee:payoff_element>
-			<isee:payoff_element name="Finance.total_investment[1]" weight="2.88157e-7">
+			<isee:payoff_element name="Finance.total_investment[1]" weight="2.74e-7">
 				<isee:time_range type="terminal_value"/>
 			</isee:payoff_element>
-			<isee:payoff_element name="GDP.Nominal_GDP[1]" weight="5.42877e-8">
+			<isee:payoff_element name="GDP.Nominal_GDP[1]" weight="4.36341e-8">
 				<isee:time_range type="terminal_value"/>
 			</isee:payoff_element>
-			<isee:payoff_element name="Government.government_consumption[1]" weight="0.0000049757">
+			<isee:payoff_element name="Government.government_consumption[1]" weight="0.00000277341">
 				<isee:time_range type="terminal_value"/>
 			</isee:payoff_element>
-			<isee:payoff_element name="Inflation.agriculture_percentage_of_GDP[1]" weight="1.34182">
+			<isee:payoff_element name="Inflation.agriculture_percentage_of_GDP[1]" weight="1.3681">
 				<isee:time_range type="terminal_value"/>
 			</isee:payoff_element>
-			<isee:payoff_element name='GDP."Real_GDP_in_2021c$"[1]' weight="2.02198e-7">
+			<isee:payoff_element name='GDP."Real_GDP_in_2021c$"[1]' weight="1.70882e-7">
 				<isee:time_range type="terminal_value"/>
 			</isee:payoff_element>
-			<isee:payoff_element name="Government.debt_to_GDP_ratio[1]" weight="268.224">
+			<isee:payoff_element name="Government.debt_to_GDP_ratio[1]" weight="191.115">
 				<isee:time_range type="terminal_value"/>
 			</isee:payoff_element>
 		</isee:payoff_specs>
@@ -2244,6 +2244,8 @@ mountain glaciers (metre)} + Sea_Level.SLR_from_Greenland_Ice_Sheet_by_PCTILE[PC
 				<connect2 to="Food_Demand.Population" from="Demographics.Population"/>
 				<connect to="Freshwater.Population_1" from="Demographics.Population"/>
 				<connect2 to="Freshwater.Population_1" from="Demographics.Population"/>
+				<connect to="Government.Population" from="Demographics.Population"/>
+				<connect2 to="Government.Population" from="Demographics.Population"/>
 				<connect to="Sea_level_rise_costs_and_impacts.Population" from="Demographics.Population"/>
 				<connect2 to="Sea_level_rise_costs_and_impacts.Population" from="Demographics.Population"/>
 				<connect to="Sea_level_rise_costs_and_impacts.Population_1" from="Demographics.Population"/>
@@ -3107,6 +3109,8 @@ mountain glaciers (metre)} + Sea_Level.SLR_from_Greenland_Ice_Sheet_by_PCTILE[PC
 				<connect2 to="Government.Oil_Investments_in_Fossil_Energy_Capital" from="energy_investments.Oil_Gross_Investments_in_Fossil_Energy_Capital"/>
 				<connect to="Government.Oil_Investments_in_Fossil_Fuel_Extraction_Capital" from="energy_investments.Oil_Gross_Investments_in_Fossil_Fuel_Extraction_Capital"/>
 				<connect2 to="Government.Oil_Investments_in_Fossil_Fuel_Extraction_Capital" from="energy_investments.Oil_Gross_Investments_in_Fossil_Fuel_Extraction_Capital"/>
+				<connect to="Government.Population" from="Demographics.Population"/>
+				<connect2 to="Government.Population" from="Demographics.Population"/>
 				<connect to="Government.start_year" from="Government_Regulations.start_year"/>
 				<connect2 to="Government.start_year" from="Government_Regulations.start_year"/>
 				<connect to="Government.Surface_Temperature_Anomaly" from="Energy_Balance_Model.Surface_Temperature_Anomaly"/>
@@ -3249,7 +3253,7 @@ mountain glaciers (metre)} + Sea_Level.SLR_from_Greenland_Ice_Sheet_by_PCTILE[PC
 				<isee:iframe color="black" background="white" text_align="left" vertical_text_align="top" font_size="12pt" border_width="thin" border_style="solid"/>
 				<isee:financial_table color="black" background="#E0E0E0" text_align="right" font_size="12pt" hide_border="false" auto_fit="true" first_column_width="250" other_column_width="100" header_font_style="normal" header_font_weight="bold" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="14pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 			</style>
-			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="3" isee:page_rows="8" isee:scroll_x="3" isee:scroll_y="328" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
+			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="4" isee:page_rows="8" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
 				<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
 					<stock color="blue" background="white" font_color="blue" font_size="11pt" label_side="top">
 						<shape type="rectangle" width="45" height="35"/>
@@ -3691,6 +3695,165 @@ mountain glaciers (metre)} + Sea_Level.SLR_from_Greenland_Ice_Sheet_by_PCTILE[PC
 					<from>Economy</from>
 					<to>Resources</to>
 				</connector>
+				<stacked_container uid="156" x="1155" y="694" width="568" height="477" visible_index="9">
+					<graph width="568" height="477" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="8" num_x_labels="13" num_y_labels="8" title="Atmospheric CO2 Concentration" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
+							<entity name="CO2_Forcing.Atmospheric_CO2_Concentration[1]"/>
+						</plot>
+					</graph>
+					<graph width="568" height="477" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="9" num_x_labels="13" num_y_labels="9" title="Surface Temperature Anomaly" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
+							<entity name="Energy_Balance_Model.Surface_Temperature_Anomaly[1]"/>
+						</plot>
+					</graph>
+					<graph width="568" height="477" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="9" num_x_labels="13" num_y_labels="9" title="Global Sea Level Anomaly" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
+							<entity name="Sea_Level.Total_global_SLR[1]"/>
+						</plot>
+					</graph>
+					<graph width="568" height="477" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="7" num_x_labels="13" num_y_labels="7" title="Heating Degree Days Per Person Per Year" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
+							<entity name="energy_demand.HDD[1]"/>
+							<scale max="1500"/>
+						</plot>
+					</graph>
+					<graph width="568" height="477" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="7" num_x_labels="13" num_y_labels="7" title="Cooling Degree Days Per Person Per Year" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="blue" isee:keep_zero_visible="false" pen_width="1" index="0" show_y_axis="true">
+							<entity name="energy_demand.CDD[1]"/>
+							<scale min="500"/>
+						</plot>
+					</graph>
+					<graph width="568" height="477" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="7" num_x_labels="13" num_y_labels="7" title="Number of record breaking events experienced per person per year" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="blue" isee:keep_zero_visible="false" pen_width="1" index="0" show_y_axis="true">
+							<entity name="Energy_Balance_Model.Climate_indices_with_record_breaking_exposure_per_person_per_year[1]"/>
+						</plot>
+					</graph>
+					<graph width="568" height="477" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="8" num_x_labels="13" num_y_labels="8" title="Global Economic Output (GDP)" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_title="Giga$(Constant 2021)/Year" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
+							<format scale_by="1" delimit_000s="true"/>
+							<entity name='GDP."Real_GDP_in_2021c$"[1]'/>
+						</plot>
+					</graph>
+					<graph width="568" height="477" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="7" num_x_labels="13" num_y_labels="7" title="Inflation Rate" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_title="% per Year" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
+							<format scale_by="1" display_as="percent"/>
+							<entity name="Inflation.Inflation_Rate_as_Percent[1]"/>
+						</plot>
+					</graph>
+					<graph width="568" height="477" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="9" num_x_labels="13" num_y_labels="9" title="Unemployment Rate" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
+							<format scale_by="1" display_as="percent"/>
+							<entity name="Employment.unemployment_percentage[1]"/>
+						</plot>
+					</graph>
+					<graph width="568" height="477" type="area" isee:sum_stacked_legend="true" isee:stacked_show_hover_values="true" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="9" num_x_labels="13" num_y_labels="9" title="Share Total Income for Wages" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
+							<entity name="Circular_Flow.net_worker_income[1]"/>
+						</plot>
+						<plot color="red" isee:keep_zero_visible="true" pen_width="1" index="1" show_y_axis="true">
+							<entity name="Circular_Flow.net_owner_income[1]"/>
+						</plot>
+						<plot color="fuchsia" isee:keep_zero_visible="true" pen_width="1" index="2" show_y_axis="true">
+							<entity name="Government.total_public_tax_income[1]"/>
+						</plot>
+					</graph>
+					<graph width="568" height="477" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="11" num_x_labels="13" num_y_labels="11" title="Productivity (All Production Factors)" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
+							<entity name="Employment.realised_productivity[1]"/>
+						</plot>
+					</graph>
+					<graph width="568" height="477" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="8" num_x_labels="13" num_y_labels="8" title="Transfer Payments per Recipient" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
+							<format scale_by="1" delimit_000s="true" display_as="currency"/>
+							<entity name="Government.transfer_payments_per_recipient[1]"/>
+						</plot>
+					</graph>
+				</stacked_container>
+				<stacked_container uid="157" x="1155.17" y="1181.35" width="567.66" height="457.667">
+					<graph width="567.66" height="457.667" type="area" isee:sum_stacked_legend="true" isee:stacked_show_hover_values="true" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="6" num_x_labels="13" num_y_labels="6" title="Energy Output by Type" isee:fill_intensity="0.5" isee:stacked_area_max="150000" to="2100" isee:allow_zero_axis="true" left_axis_title="TWh/Year" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="black" title="Coal" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
+							<format scale_by="1" delimit_000s="true"/>
+							<entity name="fossil_energy_coal.Secondary_Fossil_Energy_Output[1]"/>
+						</plot>
+						<plot color="#552B00" title="Oil" isee:keep_zero_visible="true" pen_width="1" index="1" show_y_axis="true">
+							<format scale_by="1" delimit_000s="true"/>
+							<entity name="fossil_energy_oil.Secondary_Fossil_Energy_Output[1]"/>
+						</plot>
+						<plot color="#9C4E00" title="Gas" isee:keep_zero_visible="true" pen_width="1" index="2" show_y_axis="true">
+							<format scale_by="1" delimit_000s="true"/>
+							<entity name="fossil_energy_gas.Secondary_Fossil_Energy_Output[1]"/>
+						</plot>
+						<plot color="#FFE54F" title="Wind and Solar" isee:keep_zero_visible="true" pen_width="1" index="3" show_y_axis="true">
+							<format scale_by="1" delimit_000s="true"/>
+							<entity name="wind_and_solar_energy.Wind_and_Solar_Energy_Output[1]"/>
+						</plot>
+						<plot color="#00AAFF" title="Hydro" isee:keep_zero_visible="true" pen_width="1" index="4" show_y_axis="true">
+							<format scale_by="1" delimit_000s="true"/>
+							<entity name="hydropower_energy.Hydropower_Energy_Output[1]"/>
+						</plot>
+						<plot color="#FF55FF" title="Nuclear" isee:keep_zero_visible="true" pen_width="1" index="5" show_y_axis="true">
+							<format scale_by="1" delimit_000s="true"/>
+							<entity name="nuclear_energy.Nuclear_Energy_Output[1]"/>
+						</plot>
+						<plot color="#00AA00" title="Other Energy" isee:keep_zero_visible="true" pen_width="1" index="6" show_y_axis="true">
+							<format scale_by="1" delimit_000s="true"/>
+							<entity name="other_energy.Other_Energy_Output[1]"/>
+						</plot>
+						<plot color="#00D900" title="Biofuel" isee:keep_zero_visible="true" pen_width="1" index="7" show_y_axis="true">
+							<format scale_by="1" delimit_000s="true"/>
+							<entity name="bio_fuel_energy.bio_fuel_primary_energy[1]"/>
+						</plot>
+					</graph>
+				</stacked_container>
+				<stacked_container uid="158" x="1743.67" y="1183.02" width="567" height="457">
+					<graph width="567" height="457" type="area" isee:sum_stacked_legend="true" isee:stacked_show_hover_values="true" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="5" num_x_labels="13" num_y_labels="5" title="Energy Investments by Type" isee:fill_intensity="0.5" isee:stacked_area_max="2000000000000" to="2100" isee:allow_zero_axis="true" left_axis_title="$(Constant 2021)/Year" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="black" pen_style="dashed" title="Coal Extraction" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
+							<format display_as="currency"/>
+							<entity name="energy_investments.Coal_Gross_Investments_in_Fossil_Fuel_Extraction_Capital[1]"/>
+						</plot>
+						<plot color="black" title="Coal Conversion to Energy" isee:keep_zero_visible="true" pen_width="1" index="1" show_y_axis="true">
+							<format display_as="currency"/>
+							<entity name="energy_investments.Coal_Gross_Investments_in_Fossil_Energy_Capital[1]"/>
+						</plot>
+						<plot color="#552B00" pen_style="dashed" title="Oil Extraction" isee:keep_zero_visible="true" pen_width="1" index="2" show_y_axis="true">
+							<format display_as="currency"/>
+							<entity name="energy_investments.Oil_Gross_Investments_in_Fossil_Fuel_Extraction_Capital[1]"/>
+						</plot>
+						<plot color="#552B00" title="Oil Conversion to Energy" isee:keep_zero_visible="true" pen_width="1" index="3" show_y_axis="true">
+							<format display_as="currency"/>
+							<entity name="energy_investments.Oil_Gross_Investments_in_Fossil_Energy_Capital[1]"/>
+						</plot>
+						<plot color="#9C4E00" pen_style="dashed" title="Gas Extraction" isee:keep_zero_visible="true" pen_width="1" index="4" show_y_axis="true">
+							<format display_as="currency"/>
+							<entity name="energy_investments.Gas_Gross_Investments_in_Fossil_Fuel_Extraction_Capital[1]"/>
+						</plot>
+						<plot color="#9C4E00" title="Gas Conversion to Energy" isee:keep_zero_visible="true" pen_width="1" index="5" show_y_axis="true">
+							<format display_as="currency"/>
+							<entity name="energy_investments.Gas_Gross_Investments_in_Fossil_Energy_Capital[1]"/>
+						</plot>
+						<plot color="#FFE54F" title="Solar and Wind" isee:keep_zero_visible="true" pen_width="1" index="6" show_y_axis="true">
+							<format display_as="currency"/>
+							<entity name="energy_investments.Gross_Investments_in_Solar_and_Wind_Energy_Capacity[1]"/>
+						</plot>
+						<plot color="#00AAFF" title="Hydro" isee:keep_zero_visible="true" pen_width="1" index="7" show_y_axis="true">
+							<format display_as="currency"/>
+							<entity name="energy_investments.Gross_Investments_in_Hydropower_Energy_capacity[1]"/>
+						</plot>
+						<plot color="#FF55FF" title="Nuclear" isee:keep_zero_visible="true" pen_width="1" index="8" show_y_axis="true">
+							<format display_as="currency"/>
+							<entity name="energy_investments.Investments_in_Nuclear_Capacity[1]"/>
+						</plot>
+						<plot color="#00AA00" title="Other Energy" isee:keep_zero_visible="true" pen_width="1" index="9" show_y_axis="true">
+							<format display_as="currency"/>
+							<entity name="energy_investments.Gross_Investments_in_Other_Capacity[1]"/>
+						</plot>
+						<plot color="#00D900" title="Biofuel" isee:keep_zero_visible="true" pen_width="1" index="10" show_y_axis="true">
+							<format display_as="currency"/>
+							<entity name="energy_investments.Gross_Investments_in_Biofuel_Capacity[1]"/>
+						</plot>
+					</graph>
+				</stacked_container>
+				<text_box uid="159" x="1873" y="1649" width="260" height="58">We want to separate the oil conversion to energy capital from the biofuel conversion to energy capital so there is a second green section</text_box>
 			</view>
 			<view isee:template_view="template:1" isee:name="Landing Page without image" isee:original_design="Deluxe Prev-Next Blue Green Pastel" background="white" page_width="1066" page_height="600" home_view="true" type="interface">
 				<style>
@@ -4525,7 +4688,7 @@ Lorem ipsum dolor sit amet</text_box>
 				<isee:iframe color="black" background="white" text_align="left" vertical_text_align="top" font_size="12pt" border_width="thin" border_style="solid"/>
 				<isee:financial_table color="black" background="#E0E0E0" text_align="right" font_size="12pt" hide_border="false" auto_fit="true" first_column_width="250" other_column_width="100" header_font_style="normal" header_font_weight="bold" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="14pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 			</style>
-			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="2" isee:page_rows="2" isee:scroll_y="384.375" zoom="160" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
+			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="2" isee:page_rows="2" zoom="160" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
 				<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
 					<stock color="blue" background="white" font_color="blue" font_size="9pt" label_side="top">
 						<shape type="rectangle" width="45" height="35"/>

--- a/FRIDA.stmx
+++ b/FRIDA.stmx
@@ -3,7 +3,7 @@
 	<header>
 		<smile version="1.0" namespace="std, isee" uses_arrays="2" uses_conveyor="" uses_submodels=""/>
 		<name>FRIDA</name>
-		<uuid>ebad248d-d14f-4869-ab09-e6711a053740</uuid>
+		<uuid>26eef8bf-e63f-470b-b03e-68b19ca0de72</uuid>
 		<vendor>isee systems, inc.</vendor>
 		<product version="3.7.3" isee:build_number="3465" isee:saved_by_v1="true" lang="en">Stella Architect</product>
 	</header>
@@ -2347,6 +2347,8 @@ mountain glaciers (metre)} + Sea_Level.SLR_from_Greenland_Ice_Sheet_by_PCTILE[PC
 				<connect2 to="Freshwater.today" from="Climate.today"/>
 				<connect to="Government.today" from="Climate.today"/>
 				<connect2 to="Government.today" from="Climate.today"/>
+				<connect to="Government.today_1" from="Climate.today"/>
+				<connect2 to="Government.today_1" from="Climate.today"/>
 				<connect to="Grass.today" from="Climate.today"/>
 				<connect2 to="Grass.today" from="Climate.today"/>
 				<connect to="Sea_level_rise_adaptation.today" from="Climate.today"/>
@@ -3129,6 +3131,8 @@ mountain glaciers (metre)} + Sea_Level.SLR_from_Greenland_Ice_Sheet_by_PCTILE[PC
 				<connect2 to="Government.tax_rate_4" from="nuclear_energy.tax_rate"/>
 				<connect to="Government.today" from="Climate.today"/>
 				<connect2 to="Government.today" from="Climate.today"/>
+				<connect to="Government.today_1" from="Climate.today"/>
+				<connect2 to="Government.today_1" from="Climate.today"/>
 				<connect to="Government.unemployment_goal_policy" from="Government_Regulations.unemployment_goal_policy"/>
 				<connect2 to="Government.unemployment_goal_policy" from="Government_Regulations.unemployment_goal_policy"/>
 				<connect to="Inflation.animal_products_demand" from="Food_Demand.animal_products_demand"/>
@@ -3253,7 +3257,7 @@ mountain glaciers (metre)} + Sea_Level.SLR_from_Greenland_Ice_Sheet_by_PCTILE[PC
 				<isee:iframe color="black" background="white" text_align="left" vertical_text_align="top" font_size="12pt" border_width="thin" border_style="solid"/>
 				<isee:financial_table color="black" background="#E0E0E0" text_align="right" font_size="12pt" hide_border="false" auto_fit="true" first_column_width="250" other_column_width="100" header_font_style="normal" header_font_weight="bold" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="14pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 			</style>
-			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="5" isee:page_rows="8" isee:scroll_x="1290" isee:scroll_y="300" zoom="80" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
+			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="5" isee:page_rows="8" isee:scroll_x="880" isee:scroll_y="214.286" zoom="140" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
 				<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
 					<stock color="blue" background="white" font_color="blue" font_size="11pt" label_side="top">
 						<shape type="rectangle" width="45" height="35"/>
@@ -3695,58 +3699,58 @@ mountain glaciers (metre)} + Sea_Level.SLR_from_Greenland_Ice_Sheet_by_PCTILE[PC
 					<from>Economy</from>
 					<to>Resources</to>
 				</connector>
-				<stacked_container uid="156" x="1155" y="376.75" width="568" height="793.25" visible_index="10">
-					<graph width="568" height="793.25" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="8" num_x_labels="13" num_y_labels="8" title="Atmospheric CO2 Concentration" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+				<stacked_container uid="156" x="1154.71" y="372.339" width="570" height="470" visible_index="30">
+					<graph width="570" height="470" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="8" num_x_labels="13" num_y_labels="8" title="Atmospheric CO2 Concentration" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
 						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
 							<entity name="CO2_Forcing.Atmospheric_CO2_Concentration[1]"/>
 						</plot>
 					</graph>
-					<graph width="568" height="793.25" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="9" num_x_labels="13" num_y_labels="9" title="Surface Temperature Anomaly" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+					<graph width="570" height="470" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="9" num_x_labels="13" num_y_labels="9" title="Surface Temperature Anomaly" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
 						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
 							<entity name="Energy_Balance_Model.Surface_Temperature_Anomaly[1]"/>
 						</plot>
 					</graph>
-					<graph width="568" height="793.25" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="9" num_x_labels="13" num_y_labels="9" title="Global Sea Level Anomaly" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+					<graph width="570" height="470" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="9" num_x_labels="13" num_y_labels="9" title="Global Sea Level Anomaly" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
 						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
 							<entity name="Sea_Level.Total_global_SLR[1]"/>
 						</plot>
 					</graph>
-					<graph width="568" height="793.25" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="7" num_x_labels="13" num_y_labels="7" title="Heating Degree Days Per Person Per Year" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+					<graph width="570" height="470" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="7" num_x_labels="13" num_y_labels="7" title="Heating Degree Days Per Person Per Year" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
 						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
 							<entity name="energy_demand.HDD[1]"/>
 							<scale max="1500"/>
 						</plot>
 					</graph>
-					<graph width="568" height="793.25" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="7" num_x_labels="13" num_y_labels="7" title="Cooling Degree Days Per Person Per Year" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+					<graph width="570" height="470" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="7" num_x_labels="13" num_y_labels="7" title="Cooling Degree Days Per Person Per Year" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
 						<plot color="blue" isee:keep_zero_visible="false" pen_width="1" index="0" show_y_axis="true">
 							<entity name="energy_demand.CDD[1]"/>
 							<scale min="500"/>
 						</plot>
 					</graph>
-					<graph width="568" height="793.25" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="7" num_x_labels="13" num_y_labels="7" title="Number of record breaking events experienced per person per year" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+					<graph width="570" height="470" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="7" num_x_labels="13" num_y_labels="7" title="Number of record breaking events experienced per person per year" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
 						<plot color="blue" isee:keep_zero_visible="false" pen_width="1" index="0" show_y_axis="true">
 							<entity name="Energy_Balance_Model.Climate_indices_with_record_breaking_exposure_per_person_per_year[1]"/>
 						</plot>
 					</graph>
-					<graph width="568" height="793.25" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="8" num_x_labels="13" num_y_labels="8" title="Global Economic Output (GDP)" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_title="Giga$(Constant 2021)/Year" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+					<graph width="570" height="470" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="8" num_x_labels="13" num_y_labels="8" title="Global Economic Output (GDP)" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_title="Giga$(Constant 2021)/Year" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
 						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
 							<format scale_by="1" delimit_000s="true"/>
 							<entity name='GDP."Real_GDP_in_2021c$"[1]'/>
 						</plot>
 					</graph>
-					<graph width="568" height="793.25" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="7" num_x_labels="13" num_y_labels="7" title="Inflation Rate" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_title="% per Year" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+					<graph width="570" height="470" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="7" num_x_labels="13" num_y_labels="7" title="Inflation Rate" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_title="% per Year" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
 						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
 							<format scale_by="1" display_as="percent"/>
 							<entity name="Inflation.Inflation_Rate_as_Percent[1]"/>
 						</plot>
 					</graph>
-					<graph width="568" height="793.25" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="9" num_x_labels="13" num_y_labels="9" title="Unemployment Rate" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+					<graph width="570" height="470" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="9" num_x_labels="13" num_y_labels="9" title="Unemployment Rate" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
 						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
 							<format scale_by="1" display_as="percent"/>
 							<entity name="Employment.unemployment_percentage[1]"/>
 						</plot>
 					</graph>
-					<graph width="568" height="793.25" type="area" isee:sum_stacked_legend="true" isee:stacked_show_hover_values="true" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="9" num_x_labels="13" num_y_labels="9" title="Income" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+					<graph width="570" height="470" type="area" isee:sum_stacked_legend="true" isee:stacked_show_hover_values="true" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="9" num_x_labels="13" num_y_labels="9" title="Income" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
 						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
 							<entity name="Circular_Flow.net_worker_income[1]"/>
 						</plot>
@@ -3757,7 +3761,7 @@ mountain glaciers (metre)} + Sea_Level.SLR_from_Greenland_Ice_Sheet_by_PCTILE[PC
 							<entity name="Government.total_public_tax_income[1]"/>
 						</plot>
 					</graph>
-					<graph width="568" height="793.25" type="area" isee:sum_stacked_legend="true" isee:stacked_show_hover_values="false" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="8" num_x_labels="13" num_y_labels="8" title="Real GDP" isee:fill_intensity="1" to="2100" isee:allow_zero_axis="true" left_axis_title="Giga$(2021) per Year" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+					<graph width="570" height="470" type="area" isee:sum_stacked_legend="true" isee:stacked_show_hover_values="false" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="8" num_x_labels="13" num_y_labels="8" title="Real GDP" isee:fill_intensity="1" to="2100" isee:allow_zero_axis="true" left_axis_title="Giga$(2021) per Year" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
 						<plot color="#00008F" title="Owner Consumption" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
 							<format scale_by="1" delimit_000s="true" display_as="currency"/>
 							<entity name='GDP."owner_consumption_in_2021c$"[1]'/>
@@ -3766,32 +3770,199 @@ mountain glaciers (metre)} + Sea_Level.SLR_from_Greenland_Ice_Sheet_by_PCTILE[PC
 							<format scale_by="1" delimit_000s="true" display_as="currency"/>
 							<entity name='GDP."worker_consumption_excluding_transfers_in_2021c$"[1]'/>
 						</plot>
-						<plot color="#0BF7EC" title="Government Transfers" isee:keep_zero_visible="true" pen_width="1" index="2" show_y_axis="true">
+						<plot color="#2D994A" title="Government Consumption Excluding Climate Repairs" isee:keep_zero_visible="true" pen_width="1" index="2" show_y_axis="true">
+							<entity name='Government."government_spending_without_climate_impact_in_2021c$"[1]'/>
+						</plot>
+						<plot color="#5CD86B" title="Government Consumption on Climate Repairs" isee:keep_zero_visible="true" pen_width="1" index="3" show_y_axis="true">
+							<entity name='Government."government_spending_because_of_climate_in_2021c$"[1]'/>
+						</plot>
+						<plot color="#0BF7EC" title="Government Transfers" isee:keep_zero_visible="true" pen_width="1" index="4" show_y_axis="true">
 							<format scale_by="1" delimit_000s="true" display_as="currency"/>
 							<entity name='GDP."government_transfers_in_2021c$"[1]'/>
 						</plot>
-						<plot color="#008F44" title="Government Consumption" isee:keep_zero_visible="true" pen_width="1" index="3" show_y_axis="true">
-							<format scale_by="1" delimit_000s="true" display_as="currency"/>
-							<entity name='GDP."government_consumption_in_2021c$"[1]'/>
-						</plot>
-						<plot color="#FEFF00" title="Government Investment" isee:keep_zero_visible="true" pen_width="1" index="4" show_y_axis="true">
+						<plot color="#FEFF00" title="Government Investment" isee:keep_zero_visible="true" pen_width="1" index="5" show_y_axis="true">
 							<format scale_by="1" delimit_000s="true" display_as="currency"/>
 							<entity name='GDP."public_investment_in_2021c$"[1]'/>
 						</plot>
-						<plot color="#F6950E" title="Private Investment" isee:keep_zero_visible="true" pen_width="1" index="5" show_y_axis="true">
+						<plot color="#F6950E" title="Private Investment" isee:keep_zero_visible="true" pen_width="1" index="6" show_y_axis="true">
 							<format scale_by="1" delimit_000s="true" display_as="currency"/>
 							<entity name='GDP."private_investment_in_in_2021c$"[1]'/>
 						</plot>
 					</graph>
-					<graph width="568" height="793.25" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="11" num_x_labels="13" num_y_labels="11" title="Productivity (All Production Factors)" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+					<graph width="570" height="470" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="11" num_x_labels="13" num_y_labels="11" title="Productivity (All Production Factors)" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
 						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
 							<entity name="Employment.realised_productivity[1]"/>
 						</plot>
 					</graph>
-					<graph width="568" height="793.25" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="8" num_x_labels="13" num_y_labels="8" title="Transfer Payments per Recipient" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+					<graph width="570" height="470" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="11" num_x_labels="13" num_y_labels="11" title="Worker Share of Net Income" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
+							<format scale_by="1" display_as="percent"/>
+							<entity name="Circular_Flow.worker_share_of_net_income[1]"/>
+							<scale max="100"/>
+						</plot>
+					</graph>
+					<graph width="570" height="470" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="8" num_x_labels="13" num_y_labels="8" title="Transfer Payments per Recipient" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
 						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
 							<format scale_by="1" delimit_000s="true" display_as="currency"/>
 							<entity name="Government.transfer_payments_per_recipient[1]"/>
+						</plot>
+					</graph>
+					<graph width="570" height="470" type="area" isee:sum_stacked_legend="true" isee:stacked_show_hover_values="true" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="7" num_x_labels="13" num_y_labels="7" title="Net Primary Production" isee:fill_intensity="1" isee:stacked_area_max="150" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="#307739" title="Mature Forest" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
+							<entity name="Forest.mature_forest_net_primary_production[1]"/>
+						</plot>
+						<plot color="#67CB64" title="Young Forest" isee:keep_zero_visible="true" pen_width="1" index="1" show_y_axis="true">
+							<entity name="Forest.young_forest_net_primary_production[1]"/>
+						</plot>
+						<plot color="#FBED00" title="Cropland" isee:keep_zero_visible="true" pen_width="1" index="2" show_y_axis="true">
+							<entity name="Crop.cropland_net_primary_production[1]"/>
+						</plot>
+						<plot color="#88FE00" title="Grassland" isee:keep_zero_visible="true" pen_width="1" index="3" show_y_axis="true">
+							<entity name="Grass.grassland_net_primary_production[1]"/>
+						</plot>
+						<plot color="#FF0021" title="Degraded Land" isee:keep_zero_visible="true" pen_width="1" index="4" show_y_axis="true">
+							<entity name="degraded_land_soil_carbon.degraded_land_litter[1]"/>
+						</plot>
+					</graph>
+					<graph width="570" height="470" type="area" isee:sum_stacked_legend="true" isee:stacked_show_hover_values="true" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="9" num_x_labels="13" num_y_labels="9" title="Human Food Production" isee:fill_intensity="1" to="2100" isee:allow_zero_axis="true" left_axis_title="PCal/Year" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="blue" title="Vegetal Products" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
+							<entity name="Food_Demand.crop_demand_for_food[1]"/>
+						</plot>
+						<plot color="red" title="Animal Products" isee:keep_zero_visible="true" pen_width="1" index="1" show_y_axis="true">
+							<entity name="Animal_Products.animal_products_production[1]"/>
+						</plot>
+					</graph>
+					<graph width="570" height="470" type="area" isee:sum_stacked_legend="true" isee:stacked_show_hover_values="true" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="7" num_x_labels="13" num_y_labels="7" title="Crop Demand" isee:fill_intensity="1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="blue" title="Vegetal Products" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
+							<entity name="Food_Demand.crop_demand_for_food[1]"/>
+						</plot>
+						<plot color="red" title="Feed" isee:keep_zero_visible="true" pen_width="1" index="1" show_y_axis="true">
+							<entity name="Food_Demand.crop_demand_for_feed[1]"/>
+						</plot>
+						<plot color="fuchsia" title="Bio Fuel" isee:keep_zero_visible="true" pen_width="1" index="2" show_y_axis="true">
+							<entity name="bio_fuel_energy.crops_demanded_for_bio_fuel[1]"/>
+						</plot>
+					</graph>
+					<graph width="570" height="470" type="area" isee:sum_stacked_legend="true" isee:stacked_show_hover_values="true" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="9" num_x_labels="13" num_y_labels="9" title="Crop Production" isee:fill_intensity="1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="blue" title="Vegetal Products" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
+							<entity name="Food_Demand.crop_demand_for_food[1]"/>
+						</plot>
+						<plot color="red" title="Feed Production" isee:keep_zero_visible="true" pen_width="1" index="1" show_y_axis="true">
+							<entity name="Animal_Products.feed_production[1]"/>
+						</plot>
+						<plot color="fuchsia" title="Biofuel Feedstock" isee:keep_zero_visible="true" pen_width="1" index="2" show_y_axis="true">
+							<entity name="Food_Demand.crops_for_energy[1]"/>
+						</plot>
+					</graph>
+					<graph width="570" height="470" type="area" isee:sum_stacked_legend="true" isee:stacked_show_hover_values="true" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="9" num_x_labels="13" num_y_labels="9" title="Crop Production by Use" isee:fill_intensity="1" to="2100" isee:allow_zero_axis="true" left_axis_title="PCal/Year" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="blue" title="Vegetal Products" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
+							<entity name="Food_Demand.crop_demand_for_food[1]"/>
+						</plot>
+						<plot color="red" title="Animal Products" isee:keep_zero_visible="true" pen_width="1" index="1" show_y_axis="true">
+							<entity name="Animal_Products.animal_products_production[1]"/>
+						</plot>
+						<plot color="#B30000" title="Calories Consumed by Animals not Transferred to Humans" isee:keep_zero_visible="true" pen_width="1" index="2" show_y_axis="true">
+							<entity name="Animal_Products.calories_consumed_by_animals_not_transferred_to_humans[1]"/>
+						</plot>
+						<plot color="#F612FF" title="Biofuel Feedstock" isee:keep_zero_visible="true" pen_width="1" index="3" show_y_axis="true">
+							<entity name="Food_Demand.crops_for_energy[1]"/>
+						</plot>
+					</graph>
+					<graph width="570" height="470" type="area" isee:sum_stacked_legend="true" isee:stacked_show_hover_values="true" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="9" num_x_labels="13" num_y_labels="9" title="Water Use" isee:fill_intensity="1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="blue" title="Agricultural" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
+							<entity name="Freshwater.agricultural_water_withdrawal[1]"/>
+						</plot>
+						<plot color="red" title="Non Agricultural" isee:keep_zero_visible="true" pen_width="1" index="1" show_y_axis="true">
+							<entity name="Freshwater.non_agricultural_water_withdrawl[1]"/>
+						</plot>
+					</graph>
+					<graph width="570" height="470" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="9" num_x_labels="13" num_y_labels="9" title="Water Sustainability (to be combined with Water Use)" isee:fill_intensity="1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="blue" title="Total Water Use" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
+							<entity name="Freshwater.total_water_withdrawal[1]"/>
+						</plot>
+						<plot color="red" title="Unsustainable Water Use" isee:keep_zero_visible="true" pen_width="1" index="1" show_y_axis="true">
+							<entity name="Freshwater.unsustainable_groundwater_withdrawal[1]"/>
+						</plot>
+					</graph>
+					<graph width="570" height="470" type="area" isee:sum_stacked_legend="true" isee:stacked_show_hover_values="true" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="9" num_x_labels="13" num_y_labels="9" title="Fertilizer by Type" isee:fill_intensity="1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="blue" title="Man Made" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
+							<entity name="Land_Nutrients.man_made_fertilizer_use[1]"/>
+						</plot>
+						<plot color="red" title="Manure" isee:keep_zero_visible="true" pen_width="1" index="1" show_y_axis="true">
+							<entity name="Land_Nutrients.manure_fertilizer_use[1]"/>
+						</plot>
+					</graph>
+					<graph width="570" height="470" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="9" num_x_labels="13" num_y_labels="9" isee:fill_intensity="1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
+							<entity name="Emissions.CO2_emissions_from_Food_and_Land_Use[1]"/>
+						</plot>
+					</graph>
+					<graph width="570" height="470" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="9" num_x_labels="13" num_y_labels="9" isee:fill_intensity="1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
+							<entity name="Emissions.CH4_Emissions_from_Food_and_Land_Use[1]"/>
+						</plot>
+					</graph>
+					<graph width="570" height="470" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="9" num_x_labels="13" num_y_labels="9" isee:fill_intensity="1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
+							<entity name="Emissions.N2O_Emissions_from_Food_and_Land_Use[1]"/>
+						</plot>
+					</graph>
+					<graph width="570" height="470" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="9" num_x_labels="13" num_y_labels="9" isee:fill_intensity="1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
+							<entity name="Emissions.SO2_Emissions_from_Food_and_Land_Use[1]"/>
+						</plot>
+					</graph>
+					<graph width="570" height="470" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="5" num_x_labels="13" num_y_labels="5" title="Energy Balance" isee:fill_intensity="1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="blue" isee:keep_zero_visible="false" pen_width="1" index="0" show_y_axis="true">
+							<entity name="energy_supply_vs_demand.Energy_Balance[1]"/>
+							<scale min="0.99" max="1.01"/>
+						</plot>
+					</graph>
+					<graph width="570" height="470" type="area" isee:sum_stacked_legend="true" isee:stacked_show_hover_values="true" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="5" num_x_labels="13" num_y_labels="5" title="CO2 Emissions from Energy" isee:fill_intensity="1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
+							<entity name="Emissions.CO2_emissions_from_coal[1]"/>
+						</plot>
+						<plot color="red" isee:keep_zero_visible="true" pen_width="1" index="1" show_y_axis="true">
+							<entity name="Emissions.CO2_emissions_from_oil[1]"/>
+						</plot>
+						<plot color="fuchsia" isee:keep_zero_visible="true" pen_width="1" index="2" show_y_axis="true">
+							<entity name="Emissions.CO2_emissions_from_gas[1]"/>
+						</plot>
+						<plot color="#008F44" isee:keep_zero_visible="true" pen_width="1" index="3" show_y_axis="true">
+							<entity name="Emissions.CO2_emissions_from_biofuels[1]"/>
+						</plot>
+					</graph>
+					<graph width="570" height="470" type="area" isee:sum_stacked_legend="true" isee:stacked_show_hover_values="true" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="5" num_x_labels="13" num_y_labels="5" title="CH4 Emissions from Energy" isee:fill_intensity="1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
+							<entity name="Emissions.CH4_emissions_from_coal[1]"/>
+						</plot>
+						<plot color="red" isee:keep_zero_visible="true" pen_width="1" index="1" show_y_axis="true">
+							<entity name="Emissions.CH4_emissions_from_oil[1]"/>
+						</plot>
+						<plot color="fuchsia" isee:keep_zero_visible="true" pen_width="1" index="2" show_y_axis="true">
+							<entity name="Emissions.CH4_emissions_by_gas[1]"/>
+						</plot>
+					</graph>
+					<graph width="570" height="470" type="area" isee:sum_stacked_legend="true" isee:stacked_show_hover_values="true" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="5" num_x_labels="13" num_y_labels="5" title="N2O Emissions from Energy" isee:fill_intensity="1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
+							<entity name="Emissions.N2O_emissions_by_coal[1]"/>
+						</plot>
+						<plot color="red" isee:keep_zero_visible="true" pen_width="1" index="1" show_y_axis="true">
+							<entity name="Emissions.N2O_emissions_by_oil[1]"/>
+						</plot>
+						<plot color="fuchsia" isee:keep_zero_visible="true" pen_width="1" index="2" show_y_axis="true">
+							<entity name="Emissions.N2O_emissions_by_gas[1]"/>
+						</plot>
+					</graph>
+					<graph width="570" height="470" type="area" isee:sum_stacked_legend="true" isee:stacked_show_hover_values="true" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="5" num_x_labels="13" num_y_labels="5" title="SO2 Emissions from Energy" isee:fill_intensity="1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
+							<entity name="Emissions.SO2_emissions_by_coal[1]"/>
+						</plot>
+						<plot color="red" isee:keep_zero_visible="true" pen_width="1" index="1" show_y_axis="true">
+							<entity name="Emissions.SO2_emissions_by_oil[1]"/>
+						</plot>
+						<plot color="fuchsia" isee:keep_zero_visible="true" pen_width="1" index="2" show_y_axis="true">
+							<entity name="Emissions.SO2_emissions_by_gas[1]"/>
 						</plot>
 					</graph>
 				</stacked_container>
@@ -3880,7 +4051,7 @@ mountain glaciers (metre)} + Sea_Level.SLR_from_Greenland_Ice_Sheet_by_PCTILE[PC
 					</graph>
 				</stacked_container>
 				<text_box uid="159" x="1873" y="1649" width="260" height="58">We want to separate the oil conversion to energy capital from the biofuel conversion to energy capital so there is a second green section</text_box>
-				<stacked_container uid="160" x="2323.25" y="695.917" width="567" height="473.666">
+				<stacked_container uid="160" x="2163.96" y="-140.512" width="567" height="473.666">
 					<graph width="567" height="473.666" type="area" isee:sum_stacked_legend="true" isee:stacked_show_hover_values="true" show_grid="false" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="0" num_y_grid_lines="0" num_x_labels="5" num_y_labels="3" title="Share of Gross Income" isee:fill_intensity="1" isee:stacked_area_max="1" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
 						<plot color="blue" title="Non-Bank Profits" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
 							<entity name="Circular_Flow.share_of_gross_income_from_non_bank_profits[1]"/>
@@ -3906,7 +4077,7 @@ mountain glaciers (metre)} + Sea_Level.SLR_from_Greenland_Ice_Sheet_by_PCTILE[PC
 					</graph>
 				</stacked_container>
 				<stacked_container uid="161" x="1738.83" y="371.167" width="570" height="796.916">
-					<graph width="570" height="796.916" type="area" isee:sum_stacked_legend="true" isee:stacked_show_hover_values="false" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="8" num_x_labels="13" num_y_labels="8" title="Real Gross Income" isee:fill_intensity="1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+					<graph width="570" height="796.916" type="area" isee:sum_stacked_legend="true" isee:stacked_show_hover_values="false" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="8" num_x_labels="13" num_y_labels="8" title="Real Gross Income" isee:fill_intensity="1" to="2100" isee:allow_zero_axis="true" left_axis_title="Giga$(2021) per Year" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
 						<plot color="#F7FF00" title="Owner Profits not from Bank (After Tax)" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
 							<entity name='Circular_Flow."non_bank_profits_after_tax_in_2021c$"[1]'/>
 						</plot>
@@ -3938,6 +4109,26 @@ mountain glaciers (metre)} + Sea_Level.SLR_from_Greenland_Ice_Sheet_by_PCTILE[PC
 							<entity name='Circular_Flow."wage_tax_in_2021c$"[1]'/>
 						</plot>
 					</graph>
+				</stacked_container>
+				<stacked_container uid="162" x="2341.14" y="370.857" width="465" height="498.5" visible_index="1">
+					<graph width="465" height="498.5" type="area" isee:sum_stacked_legend="true" isee:stacked_show_hover_values="true" show_grid="false" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="0" num_y_grid_lines="0" num_x_labels="13" num_y_labels="10" title="Habitable Land Area (to be converted to SqKM)" isee:fill_intensity="1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="#1F6C34" title="Mature Forest" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
+							<entity name="Land_Use.Mature_Forest[1]"/>
+						</plot>
+						<plot color="#4EC55D" title="Young Forest" isee:keep_zero_visible="true" pen_width="1" index="1" show_y_axis="true">
+							<entity name="Land_Use.Young_Forest[1]"/>
+						</plot>
+						<plot color="#FFEC00" title="Cropland" isee:keep_zero_visible="true" pen_width="1" index="2" show_y_axis="true">
+							<entity name="Land_Use.Cropland[1]"/>
+						</plot>
+						<plot color="#6DFF00" title="Grassland" isee:keep_zero_visible="true" pen_width="1" index="3" show_y_axis="true">
+							<entity name="Land_Use.Grassland[1]"/>
+						</plot>
+						<plot color="red" title="Degraded Land" isee:keep_zero_visible="true" pen_width="1" index="4" show_y_axis="true">
+							<entity name="Land_Use.Degraded_Land[1]"/>
+						</plot>
+					</graph>
+					<graph width="465" height="498.5" type="area" isee:sum_stacked_legend="true" isee:stacked_show_hover_values="true" show_grid="false" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="0" num_y_grid_lines="0" num_x_labels="13" num_y_labels="10" isee:fill_intensity="1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true"/>
 				</stacked_container>
 			</view>
 			<view isee:template_view="template:1" isee:name="Landing Page without image" isee:original_design="Deluxe Prev-Next Blue Green Pastel" background="white" page_width="1066" page_height="600" home_view="true" type="interface">

--- a/FRIDA.stmx
+++ b/FRIDA.stmx
@@ -348,7 +348,7 @@
 			<isee:parameter name="Government.public_consumption_to_transfers_ratio" scaling="100"/>
 			<isee:parameter name="Circular_Flow.wage_tax_rate" scaling="100"/>
 			<isee:parameter name="Circular_Flow.profit_tax_rate" scaling="100"/>
-			<isee:parameter name="Government.investment_share_of_public_expenditure" scaling="100"/>
+			<isee:parameter name="Government.normal_investment_share_of_public_expenditure" scaling="100"/>
 			<isee:parameter name="Finance.sensitivity_of_failure_rate_to_investment_to_gdp_ratio" scaling="100"/>
 			<isee:parameter name="Employment.max_change_in_fractional_wage_growth" scaling="1000"/>
 			<isee:parameter name="Employment.hiring_to_investment_ratio" scaling="1000"/>
@@ -388,6 +388,8 @@
 			<isee:parameter name="Finance.initial_bank_investment_growth_rate" scaling="100"/>
 			<isee:parameter name="Government.averaging_time_to_adjust_tax_based_on_income" scaling="100"/>
 			<isee:parameter name="Government.maximum_effect_of_debt_to_GDP_ratio_on_government_spending" scaling="100"/>
+			<isee:parameter name="Government.sensitivity_of_effect_of_sta_on_government_investment" scaling="100"/>
+			<isee:parameter name="Finance.sensitivity_of_effect_of_sta_on_failure_rate[1]" scaling="100"/>
 			<isee:payoff name="Economic Payoff" action="min"/>
 		</isee:optimizer_specs>
 		<isee:optimizer_specs name="Employment Sector Shares" method="Powell" use_additional_starts_file="false" additional_starts="0" report_interval="1" confidence_range="0">
@@ -710,37 +712,37 @@
 			</isee:payoff_element>
 		</isee:payoff_specs>
 		<isee:payoff_specs name="Economic Payoff" calibration="true" recompute_weights="true" compare_tolerance="0" compare_type="ls" compare_run="Calibration Data">
-			<isee:payoff_element name="Circular_Flow.private_consumption[1]" weight="0.00000240276">
+			<isee:payoff_element name="Circular_Flow.private_consumption[1]" weight="0.00000179696">
 				<isee:time_range type="terminal_value"/>
 			</isee:payoff_element>
-			<isee:payoff_element name="Employment.Employed[1]" weight="0.000242858">
+			<isee:payoff_element name="Employment.Employed[1]" weight="0.000241131">
 				<isee:time_range type="terminal_value"/>
 			</isee:payoff_element>
-			<isee:payoff_element name="Employment.Unemployed[1]" weight="0.00595702">
+			<isee:payoff_element name="Employment.Unemployed[1]" weight="0.00544259">
 				<isee:time_range type="terminal_value"/>
 			</isee:payoff_element>
-			<isee:payoff_element name="Employment.Wage_Rate[1]" weight="0.0000110934">
+			<isee:payoff_element name="Employment.Wage_Rate[1]" weight="0.0000124618">
 				<isee:time_range type="terminal_value"/>
 			</isee:payoff_element>
-			<isee:payoff_element name="Employment.unemployment_rate[1]" weight="26200.3">
+			<isee:payoff_element name="Employment.unemployment_rate[1]" weight="23907.7">
 				<isee:time_range type="terminal_value"/>
 			</isee:payoff_element>
-			<isee:payoff_element name="Finance.total_investment[1]" weight="2.87695e-7">
+			<isee:payoff_element name="Finance.total_investment[1]" weight="2.88157e-7">
 				<isee:time_range type="terminal_value"/>
 			</isee:payoff_element>
-			<isee:payoff_element name="GDP.Nominal_GDP[1]" weight="5.77717e-8">
+			<isee:payoff_element name="GDP.Nominal_GDP[1]" weight="5.42877e-8">
 				<isee:time_range type="terminal_value"/>
 			</isee:payoff_element>
-			<isee:payoff_element name="Government.government_consumption[1]" weight="0.000003722">
+			<isee:payoff_element name="Government.government_consumption[1]" weight="0.0000049757">
 				<isee:time_range type="terminal_value"/>
 			</isee:payoff_element>
-			<isee:payoff_element name="Inflation.agriculture_percentage_of_GDP[1]" weight="1.40737">
+			<isee:payoff_element name="Inflation.agriculture_percentage_of_GDP[1]" weight="1.34182">
 				<isee:time_range type="terminal_value"/>
 			</isee:payoff_element>
-			<isee:payoff_element name='GDP."Real_GDP_in_2021c$"[1]' weight="1.99929e-7">
+			<isee:payoff_element name='GDP."Real_GDP_in_2021c$"[1]' weight="2.02198e-7">
 				<isee:time_range type="terminal_value"/>
 			</isee:payoff_element>
-			<isee:payoff_element name="Government.debt_to_GDP_ratio[1]" weight="228.92">
+			<isee:payoff_element name="Government.debt_to_GDP_ratio[1]" weight="268.224">
 				<isee:time_range type="terminal_value"/>
 			</isee:payoff_element>
 		</isee:payoff_specs>
@@ -756,7 +758,7 @@
 			</isee:payoff_element>
 		</isee:payoff_specs>
 		<isee:payoff_specs name="Real GDP" calibration="true" recompute_weights="true" compare_tolerance="0" compare_type="ls" compare_run="Calibration Data">
-			<isee:payoff_element name='GDP."Real_GDP_in_2021c$"[1]' weight="1.95292e-7">
+			<isee:payoff_element name='GDP."Real_GDP_in_2021c$"[1]' weight="2.13398e-7">
 				<isee:time_range type="terminal_value"/>
 			</isee:payoff_element>
 		</isee:payoff_specs>
@@ -2301,6 +2303,8 @@ mountain glaciers (metre)} + Sea_Level.SLR_from_Greenland_Ice_Sheet_by_PCTILE[PC
 				<connect2 to="energy_demand.switch_energy_damage" from="Climate.switch_energy_damage"/>
 				<connect to="Finance.switch_economy_damage" from="Climate.switch_finance_damage"/>
 				<connect2 to="Finance.switch_economy_damage" from="Climate.switch_finance_damage"/>
+				<connect to="Government.switch_government_damage" from="Climate.switch_government_damage"/>
+				<connect2 to="Government.switch_government_damage" from="Climate.switch_government_damage"/>
 				<connect to="Employment.switch_labor_damage" from="Climate.switch_labor_damage"/>
 				<connect2 to="Employment.switch_labor_damage" from="Climate.switch_labor_damage"/>
 				<connect to="Forest.switch_land_carbon_impact" from="Climate.switch_land_carbon_impact"/>
@@ -2339,6 +2343,8 @@ mountain glaciers (metre)} + Sea_Level.SLR_from_Greenland_Ice_Sheet_by_PCTILE[PC
 				<connect2 to="Forest.today" from="Climate.today"/>
 				<connect to="Freshwater.today" from="Climate.today"/>
 				<connect2 to="Freshwater.today" from="Climate.today"/>
+				<connect to="Government.today" from="Climate.today"/>
+				<connect2 to="Government.today" from="Climate.today"/>
 				<connect to="Grass.today" from="Climate.today"/>
 				<connect2 to="Grass.today" from="Climate.today"/>
 				<connect to="Sea_level_rise_adaptation.today" from="Climate.today"/>
@@ -2473,6 +2479,8 @@ mountain glaciers (metre)} + Sea_Level.SLR_from_Greenland_Ice_Sheet_by_PCTILE[PC
 				<connect2 to="Forest.Surface_Temperature_Anomaly_1" from="Energy_Balance_Model.Surface_Temperature_Anomaly"/>
 				<connect to="Freshwater.Surface_Temperature_Anomaly" from="Energy_Balance_Model.Surface_Temperature_Anomaly"/>
 				<connect2 to="Freshwater.Surface_Temperature_Anomaly" from="Energy_Balance_Model.Surface_Temperature_Anomaly"/>
+				<connect to="Government.Surface_Temperature_Anomaly" from="Energy_Balance_Model.Surface_Temperature_Anomaly"/>
+				<connect2 to="Government.Surface_Temperature_Anomaly" from="Energy_Balance_Model.Surface_Temperature_Anomaly"/>
 				<connect to="Grass.Surface_Temperature_Anomaly" from="Energy_Balance_Model.Surface_Temperature_Anomaly"/>
 				<connect2 to="Grass.Surface_Temperature_Anomaly" from="Energy_Balance_Model.Surface_Temperature_Anomaly"/>
 				<connect to="Sea_level_rise_Impacts_and_Adaptation.Surface_Temperature_Anomaly_1" from="Energy_Balance_Model.Surface_Temperature_Anomaly"/>
@@ -3101,6 +3109,10 @@ mountain glaciers (metre)} + Sea_Level.SLR_from_Greenland_Ice_Sheet_by_PCTILE[PC
 				<connect2 to="Government.Oil_Investments_in_Fossil_Fuel_Extraction_Capital" from="energy_investments.Oil_Gross_Investments_in_Fossil_Fuel_Extraction_Capital"/>
 				<connect to="Government.start_year" from="Government_Regulations.start_year"/>
 				<connect2 to="Government.start_year" from="Government_Regulations.start_year"/>
+				<connect to="Government.Surface_Temperature_Anomaly" from="Energy_Balance_Model.Surface_Temperature_Anomaly"/>
+				<connect2 to="Government.Surface_Temperature_Anomaly" from="Energy_Balance_Model.Surface_Temperature_Anomaly"/>
+				<connect to="Government.switch_government_damage" from="Climate.switch_government_damage"/>
+				<connect2 to="Government.switch_government_damage" from="Climate.switch_government_damage"/>
 				<connect to="Government.tax_rate" from="wind_and_solar_energy.tax_rate"/>
 				<connect2 to="Government.tax_rate" from="wind_and_solar_energy.tax_rate"/>
 				<connect to="Government.tax_rate_1" from="hydropower_energy.tax_rate"/>
@@ -3111,6 +3123,8 @@ mountain glaciers (metre)} + Sea_Level.SLR_from_Greenland_Ice_Sheet_by_PCTILE[PC
 				<connect2 to="Government.tax_rate_3" from="other_energy.tax_rate"/>
 				<connect to="Government.tax_rate_4" from="nuclear_energy.tax_rate"/>
 				<connect2 to="Government.tax_rate_4" from="nuclear_energy.tax_rate"/>
+				<connect to="Government.today" from="Climate.today"/>
+				<connect2 to="Government.today" from="Climate.today"/>
 				<connect to="Government.unemployment_goal_policy" from="Government_Regulations.unemployment_goal_policy"/>
 				<connect2 to="Government.unemployment_goal_policy" from="Government_Regulations.unemployment_goal_policy"/>
 				<connect to="Inflation.animal_products_demand" from="Food_Demand.animal_products_demand"/>
@@ -3235,7 +3249,7 @@ mountain glaciers (metre)} + Sea_Level.SLR_from_Greenland_Ice_Sheet_by_PCTILE[PC
 				<isee:iframe color="black" background="white" text_align="left" vertical_text_align="top" font_size="12pt" border_width="thin" border_style="solid"/>
 				<isee:financial_table color="black" background="#E0E0E0" text_align="right" font_size="12pt" hide_border="false" auto_fit="true" first_column_width="250" other_column_width="100" header_font_style="normal" header_font_weight="bold" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="14pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 			</style>
-			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="3" isee:page_rows="8" isee:scroll_x="135" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
+			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="3" isee:page_rows="8" isee:scroll_x="3" isee:scroll_y="328" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
 				<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
 					<stock color="blue" background="white" font_color="blue" font_size="11pt" label_side="top">
 						<shape type="rectangle" width="45" height="35"/>
@@ -4058,6 +4072,8 @@ Lorem ipsum dolor sit amet</text_box>
 				<connect2 to="Forest.Surface_Temperature_Anomaly_1" from="Energy_Balance_Model.Surface_Temperature_Anomaly"/>
 				<connect to="Freshwater.Surface_Temperature_Anomaly" from="Energy_Balance_Model.Surface_Temperature_Anomaly"/>
 				<connect2 to="Freshwater.Surface_Temperature_Anomaly" from="Energy_Balance_Model.Surface_Temperature_Anomaly"/>
+				<connect to="Government.Surface_Temperature_Anomaly" from="Energy_Balance_Model.Surface_Temperature_Anomaly"/>
+				<connect2 to="Government.Surface_Temperature_Anomaly" from="Energy_Balance_Model.Surface_Temperature_Anomaly"/>
 				<connect to="Grass.Surface_Temperature_Anomaly" from="Energy_Balance_Model.Surface_Temperature_Anomaly"/>
 				<connect2 to="Grass.Surface_Temperature_Anomaly" from="Energy_Balance_Model.Surface_Temperature_Anomaly"/>
 				<connect to="Ocean.Surface_Temperature_Anomaly" from="Energy_Balance_Model.Surface_Temperature_Anomaly"/>
@@ -4454,6 +4470,12 @@ Lorem ipsum dolor sit amet</text_box>
 				<eqn>{Enter equation for use when not hooked up to other models}</eqn>
 				<units>W/(metre^2)</units>
 			</aux>
+			<aux name="switch government damage" access="output" isee:autocreated="true">
+				<eqn>1</eqn>
+				<format precision="1"/>
+				<range min="0" max="1"/>
+				<units>dmnl</units>
+			</aux>
 		</variables>
 		<views>
 			<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
@@ -4503,7 +4525,7 @@ Lorem ipsum dolor sit amet</text_box>
 				<isee:iframe color="black" background="white" text_align="left" vertical_text_align="top" font_size="12pt" border_width="thin" border_style="solid"/>
 				<isee:financial_table color="black" background="#E0E0E0" text_align="right" font_size="12pt" hide_border="false" auto_fit="true" first_column_width="250" other_column_width="100" header_font_style="normal" header_font_weight="bold" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="14pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 			</style>
-			<view isee:show_pages="false" background="white" page_width="1123" page_height="793" isee:page_cols="2" isee:page_rows="2" zoom="160" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
+			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="2" isee:page_rows="2" isee:scroll_y="384.375" zoom="160" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
 				<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
 					<stock color="blue" background="white" font_color="blue" font_size="9pt" label_side="top">
 						<shape type="rectangle" width="45" height="35"/>
@@ -4716,6 +4738,7 @@ Lorem ipsum dolor sit amet</text_box>
 					<from>Ocean</from>
 					<to>Forcing</to>
 				</connector>
+				<aux x="304" y="764.975" name="switch government damage"/>
 			</view>
 		</views>
 	</model>
@@ -4793,7 +4816,7 @@ Lorem ipsum dolor sit amet</text_box>
 				<units>metre^3/Sv</units>
 			</aux>
 			<aux name="UNIT weight ratio of CO2 over C" access="output" isee:autocreated="true">
-				<eqn>44.009/12.0107</eqn>
+				<eqn>3.6641494667255</eqn>
 				<units>GtCO2/GtC</units>
 			</aux>
 			<aux name="UNIT Seconds per year" access="output" isee:autocreated="true">
@@ -8452,7 +8475,7 @@ kappa3 in Cummins et al 2020 https://doi.org/10.1175/JCLI-D-19-0589.1</doc>
 				<isee:iframe color="black" background="white" text_align="left" vertical_text_align="top" font_size="12pt" border_width="thin" border_style="solid"/>
 				<isee:financial_table color="black" background="#E0E0E0" text_align="right" font_size="12pt" hide_border="false" auto_fit="true" first_column_width="250" other_column_width="100" header_font_style="normal" header_font_weight="bold" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="14pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 			</style>
-			<view isee:show_pages="false" background="white" page_width="1123" page_height="793" isee:page_cols="2" isee:page_rows="2" isee:scroll_x="580" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
+			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="2" isee:page_rows="2" isee:scroll_x="580" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
 				<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
 					<stock color="blue" background="white" font_color="blue" font_size="11pt" label_side="top">
 						<shape type="rectangle" width="45" height="35"/>

--- a/FRIDA.stmx
+++ b/FRIDA.stmx
@@ -3,7 +3,7 @@
 	<header>
 		<smile version="1.0" namespace="std, isee" uses_arrays="2" uses_conveyor="" uses_submodels=""/>
 		<name>FRIDA</name>
-		<uuid>dda966fe-252b-44a1-a101-0c3526293b30</uuid>
+		<uuid>ebad248d-d14f-4869-ab09-e6711a053740</uuid>
 		<vendor>isee systems, inc.</vendor>
 		<product version="3.7.3" isee:build_number="3465" isee:saved_by_v1="true" lang="en">Stella Architect</product>
 	</header>
@@ -3253,7 +3253,7 @@ mountain glaciers (metre)} + Sea_Level.SLR_from_Greenland_Ice_Sheet_by_PCTILE[PC
 				<isee:iframe color="black" background="white" text_align="left" vertical_text_align="top" font_size="12pt" border_width="thin" border_style="solid"/>
 				<isee:financial_table color="black" background="#E0E0E0" text_align="right" font_size="12pt" hide_border="false" auto_fit="true" first_column_width="250" other_column_width="100" header_font_style="normal" header_font_weight="bold" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="14pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 			</style>
-			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="4" isee:page_rows="8" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
+			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="5" isee:page_rows="8" isee:scroll_x="1290" isee:scroll_y="300" zoom="80" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
 				<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
 					<stock color="blue" background="white" font_color="blue" font_size="11pt" label_side="top">
 						<shape type="rectangle" width="45" height="35"/>
@@ -3695,58 +3695,58 @@ mountain glaciers (metre)} + Sea_Level.SLR_from_Greenland_Ice_Sheet_by_PCTILE[PC
 					<from>Economy</from>
 					<to>Resources</to>
 				</connector>
-				<stacked_container uid="156" x="1155" y="694" width="568" height="477" visible_index="9">
-					<graph width="568" height="477" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="8" num_x_labels="13" num_y_labels="8" title="Atmospheric CO2 Concentration" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+				<stacked_container uid="156" x="1155" y="376.75" width="568" height="793.25" visible_index="10">
+					<graph width="568" height="793.25" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="8" num_x_labels="13" num_y_labels="8" title="Atmospheric CO2 Concentration" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
 						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
 							<entity name="CO2_Forcing.Atmospheric_CO2_Concentration[1]"/>
 						</plot>
 					</graph>
-					<graph width="568" height="477" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="9" num_x_labels="13" num_y_labels="9" title="Surface Temperature Anomaly" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+					<graph width="568" height="793.25" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="9" num_x_labels="13" num_y_labels="9" title="Surface Temperature Anomaly" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
 						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
 							<entity name="Energy_Balance_Model.Surface_Temperature_Anomaly[1]"/>
 						</plot>
 					</graph>
-					<graph width="568" height="477" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="9" num_x_labels="13" num_y_labels="9" title="Global Sea Level Anomaly" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+					<graph width="568" height="793.25" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="9" num_x_labels="13" num_y_labels="9" title="Global Sea Level Anomaly" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
 						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
 							<entity name="Sea_Level.Total_global_SLR[1]"/>
 						</plot>
 					</graph>
-					<graph width="568" height="477" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="7" num_x_labels="13" num_y_labels="7" title="Heating Degree Days Per Person Per Year" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+					<graph width="568" height="793.25" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="7" num_x_labels="13" num_y_labels="7" title="Heating Degree Days Per Person Per Year" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
 						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
 							<entity name="energy_demand.HDD[1]"/>
 							<scale max="1500"/>
 						</plot>
 					</graph>
-					<graph width="568" height="477" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="7" num_x_labels="13" num_y_labels="7" title="Cooling Degree Days Per Person Per Year" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+					<graph width="568" height="793.25" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="7" num_x_labels="13" num_y_labels="7" title="Cooling Degree Days Per Person Per Year" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
 						<plot color="blue" isee:keep_zero_visible="false" pen_width="1" index="0" show_y_axis="true">
 							<entity name="energy_demand.CDD[1]"/>
 							<scale min="500"/>
 						</plot>
 					</graph>
-					<graph width="568" height="477" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="7" num_x_labels="13" num_y_labels="7" title="Number of record breaking events experienced per person per year" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+					<graph width="568" height="793.25" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="7" num_x_labels="13" num_y_labels="7" title="Number of record breaking events experienced per person per year" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
 						<plot color="blue" isee:keep_zero_visible="false" pen_width="1" index="0" show_y_axis="true">
 							<entity name="Energy_Balance_Model.Climate_indices_with_record_breaking_exposure_per_person_per_year[1]"/>
 						</plot>
 					</graph>
-					<graph width="568" height="477" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="8" num_x_labels="13" num_y_labels="8" title="Global Economic Output (GDP)" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_title="Giga$(Constant 2021)/Year" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+					<graph width="568" height="793.25" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="8" num_x_labels="13" num_y_labels="8" title="Global Economic Output (GDP)" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_title="Giga$(Constant 2021)/Year" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
 						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
 							<format scale_by="1" delimit_000s="true"/>
 							<entity name='GDP."Real_GDP_in_2021c$"[1]'/>
 						</plot>
 					</graph>
-					<graph width="568" height="477" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="7" num_x_labels="13" num_y_labels="7" title="Inflation Rate" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_title="% per Year" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+					<graph width="568" height="793.25" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="7" num_x_labels="13" num_y_labels="7" title="Inflation Rate" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_title="% per Year" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
 						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
 							<format scale_by="1" display_as="percent"/>
 							<entity name="Inflation.Inflation_Rate_as_Percent[1]"/>
 						</plot>
 					</graph>
-					<graph width="568" height="477" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="9" num_x_labels="13" num_y_labels="9" title="Unemployment Rate" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+					<graph width="568" height="793.25" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="9" num_x_labels="13" num_y_labels="9" title="Unemployment Rate" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
 						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
 							<format scale_by="1" display_as="percent"/>
 							<entity name="Employment.unemployment_percentage[1]"/>
 						</plot>
 					</graph>
-					<graph width="568" height="477" type="area" isee:sum_stacked_legend="true" isee:stacked_show_hover_values="true" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="9" num_x_labels="13" num_y_labels="9" title="Share Total Income for Wages" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+					<graph width="568" height="793.25" type="area" isee:sum_stacked_legend="true" isee:stacked_show_hover_values="true" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="9" num_x_labels="13" num_y_labels="9" title="Income" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
 						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
 							<entity name="Circular_Flow.net_worker_income[1]"/>
 						</plot>
@@ -3757,12 +3757,38 @@ mountain glaciers (metre)} + Sea_Level.SLR_from_Greenland_Ice_Sheet_by_PCTILE[PC
 							<entity name="Government.total_public_tax_income[1]"/>
 						</plot>
 					</graph>
-					<graph width="568" height="477" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="11" num_x_labels="13" num_y_labels="11" title="Productivity (All Production Factors)" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+					<graph width="568" height="793.25" type="area" isee:sum_stacked_legend="true" isee:stacked_show_hover_values="false" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="8" num_x_labels="13" num_y_labels="8" title="Real GDP" isee:fill_intensity="1" to="2100" isee:allow_zero_axis="true" left_axis_title="Giga$(2021) per Year" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="#00008F" title="Owner Consumption" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
+							<format scale_by="1" delimit_000s="true" display_as="currency"/>
+							<entity name='GDP."owner_consumption_in_2021c$"[1]'/>
+						</plot>
+						<plot color="#0C2DFF" title="Worker Consumption Excluding Govt. Transfers" isee:keep_zero_visible="true" pen_width="1" index="1" show_y_axis="true">
+							<format scale_by="1" delimit_000s="true" display_as="currency"/>
+							<entity name='GDP."worker_consumption_excluding_transfers_in_2021c$"[1]'/>
+						</plot>
+						<plot color="#0BF7EC" title="Government Transfers" isee:keep_zero_visible="true" pen_width="1" index="2" show_y_axis="true">
+							<format scale_by="1" delimit_000s="true" display_as="currency"/>
+							<entity name='GDP."government_transfers_in_2021c$"[1]'/>
+						</plot>
+						<plot color="#008F44" title="Government Consumption" isee:keep_zero_visible="true" pen_width="1" index="3" show_y_axis="true">
+							<format scale_by="1" delimit_000s="true" display_as="currency"/>
+							<entity name='GDP."government_consumption_in_2021c$"[1]'/>
+						</plot>
+						<plot color="#FEFF00" title="Government Investment" isee:keep_zero_visible="true" pen_width="1" index="4" show_y_axis="true">
+							<format scale_by="1" delimit_000s="true" display_as="currency"/>
+							<entity name='GDP."public_investment_in_2021c$"[1]'/>
+						</plot>
+						<plot color="#F6950E" title="Private Investment" isee:keep_zero_visible="true" pen_width="1" index="5" show_y_axis="true">
+							<format scale_by="1" delimit_000s="true" display_as="currency"/>
+							<entity name='GDP."private_investment_in_in_2021c$"[1]'/>
+						</plot>
+					</graph>
+					<graph width="568" height="793.25" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="11" num_x_labels="13" num_y_labels="11" title="Productivity (All Production Factors)" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
 						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
 							<entity name="Employment.realised_productivity[1]"/>
 						</plot>
 					</graph>
-					<graph width="568" height="477" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="8" num_x_labels="13" num_y_labels="8" title="Transfer Payments per Recipient" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+					<graph width="568" height="793.25" comparative="true" type="time_series" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="8" num_x_labels="13" num_y_labels="8" title="Transfer Payments per Recipient" isee:fill_intensity="0.1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
 						<plot color="blue" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
 							<format scale_by="1" delimit_000s="true" display_as="currency"/>
 							<entity name="Government.transfer_payments_per_recipient[1]"/>
@@ -3854,6 +3880,65 @@ mountain glaciers (metre)} + Sea_Level.SLR_from_Greenland_Ice_Sheet_by_PCTILE[PC
 					</graph>
 				</stacked_container>
 				<text_box uid="159" x="1873" y="1649" width="260" height="58">We want to separate the oil conversion to energy capital from the biofuel conversion to energy capital so there is a second green section</text_box>
+				<stacked_container uid="160" x="2323.25" y="695.917" width="567" height="473.666">
+					<graph width="567" height="473.666" type="area" isee:sum_stacked_legend="true" isee:stacked_show_hover_values="true" show_grid="false" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="0" num_y_grid_lines="0" num_x_labels="5" num_y_labels="3" title="Share of Gross Income" isee:fill_intensity="1" isee:stacked_area_max="1" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="blue" title="Non-Bank Profits" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
+							<entity name="Circular_Flow.share_of_gross_income_from_non_bank_profits[1]"/>
+						</plot>
+						<plot color="red" title="Rent" isee:keep_zero_visible="true" pen_width="1" index="1" show_y_axis="true">
+							<entity name="Circular_Flow.share_of_gross_income_from_rent[1]"/>
+						</plot>
+						<plot color="fuchsia" title="Bank Profits" isee:keep_zero_visible="true" pen_width="1" index="2" show_y_axis="true">
+							<entity name="Circular_Flow.share_of_gross_income_from_bank_profits[1]"/>
+						</plot>
+						<plot color="#008F44" title="Owners Interest" isee:keep_zero_visible="true" pen_width="1" index="3" show_y_axis="true">
+							<entity name="Circular_Flow.share_of_gross_income_from_owner_savings_interest[1]"/>
+						</plot>
+						<plot color="#FF7F00" title="Transfers" isee:keep_zero_visible="true" pen_width="1" index="4" show_y_axis="true">
+							<entity name="Circular_Flow.share_of_gross_income_from_transfers[1]"/>
+						</plot>
+						<plot color="#7F00FF" title="Workers Interest" isee:keep_zero_visible="true" pen_width="1" index="5" show_y_axis="true">
+							<entity name="Circular_Flow.share_of_gross_income_from_worker_savings_interest[1]"/>
+						</plot>
+						<plot color="#0CA0FF" title="Wages" isee:keep_zero_visible="true" pen_width="1" index="6" show_y_axis="true">
+							<entity name="Circular_Flow.share_of_gross_income_from_wages[1]"/>
+						</plot>
+					</graph>
+				</stacked_container>
+				<stacked_container uid="161" x="1738.83" y="371.167" width="570" height="796.916">
+					<graph width="570" height="796.916" type="area" isee:sum_stacked_legend="true" isee:stacked_show_hover_values="false" show_grid="true" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="13" num_y_grid_lines="8" num_x_labels="13" num_y_labels="8" title="Real Gross Income" isee:fill_intensity="1" to="2100" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
+						<plot color="#F7FF00" title="Owner Profits not from Bank (After Tax)" isee:keep_zero_visible="true" pen_width="1" index="0" show_y_axis="true">
+							<entity name='Circular_Flow."non_bank_profits_after_tax_in_2021c$"[1]'/>
+						</plot>
+						<plot color="#FEC301" title="Owner Profits from Banks (After Tax)" isee:keep_zero_visible="true" pen_width="1" index="1" show_y_axis="true">
+							<entity name='Circular_Flow."bank_profits_after_tax_in_2021c$"[1]'/>
+						</plot>
+						<plot color="#FD7800" title="Owner Rent Income (After Tax)" isee:keep_zero_visible="true" pen_width="1" index="2" show_y_axis="true">
+							<entity name='Circular_Flow."rent_after_tax_in_2021c$"[1]'/>
+						</plot>
+						<plot color="#804D07" title="Owner Income Savings Interest" isee:keep_zero_visible="true" pen_width="1" index="3" show_y_axis="true">
+							<entity name='Circular_Flow."owner_savings_interest_in_2021c$"[1]'/>
+						</plot>
+						<plot color="#0BF7EC" title="Worker Income Government Transfers" isee:keep_zero_visible="true" pen_width="1" index="4" show_y_axis="true">
+							<entity name='Circular_Flow."transfers_in_2021c$"[1]'/>
+						</plot>
+						<plot color="#005AFF" title="Worker Income Savings Interest" isee:keep_zero_visible="true" pen_width="1" index="5" show_y_axis="true">
+							<entity name='Circular_Flow."worker_savings_interest_in_2021c$"[1]'/>
+						</plot>
+						<plot color="#0094F6" title="Worker Income Wages (After Tax)" isee:keep_zero_visible="true" pen_width="1" index="6" show_y_axis="true">
+							<entity name='Circular_Flow."wages_after_tax_in_2021c$"[1]'/>
+						</plot>
+						<plot color="lime" title="Government Income Profit Taxes" isee:keep_zero_visible="true" pen_width="1" index="7" show_y_axis="true">
+							<entity name='Circular_Flow."profit_tax_in_2021c$"[1]'/>
+						</plot>
+						<plot color="#46A02F" title="Government Income Rent Taxes" isee:keep_zero_visible="true" pen_width="1" index="8" show_y_axis="true">
+							<entity name='Circular_Flow."rent_tax_in_2021c$"[1]'/>
+						</plot>
+						<plot color="#245618" title="Government Income Wage Taxes" isee:keep_zero_visible="true" pen_width="1" index="9" show_y_axis="true">
+							<entity name='Circular_Flow."wage_tax_in_2021c$"[1]'/>
+						</plot>
+					</graph>
+				</stacked_container>
 			</view>
 			<view isee:template_view="template:1" isee:name="Landing Page without image" isee:original_design="Deluxe Prev-Next Blue Green Pastel" background="white" page_width="1066" page_height="600" home_view="true" type="interface">
 				<style>

--- a/FRIDA_Modules/Economy.itmx
+++ b/FRIDA_Modules/Economy.itmx
@@ -429,6 +429,8 @@
 				<connect2 to='Government."inflation_adjustment_b$_per_bc$"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
 				<connect to='Government."inflation_adjustment_b$_per_bc$_1"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
 				<connect2 to='Government."inflation_adjustment_b$_per_bc$_1"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
+				<connect to='Government."inflation_adjustment_b$_per_bc$_2"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
+				<connect2 to='Government."inflation_adjustment_b$_per_bc$_2"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
 				<connect to="Government.inflation_goal_policy" from="Government_Regulations.inflation_goal_policy"/>
 				<connect2 to="Government.inflation_goal_policy" from="Government_Regulations.inflation_goal_policy"/>
 				<connect to="Government.Investments_in_Biofuel_Capacity" from="energy_investments.Gross_Investments_in_Biofuel_Capacity"/>
@@ -473,6 +475,8 @@
 				<connect2 to="Government.tax_rate_4" from="nuclear_energy.tax_rate"/>
 				<connect to="Government.today" from="Climate.today"/>
 				<connect2 to="Government.today" from="Climate.today"/>
+				<connect to="Government.today_1" from="Climate.today"/>
+				<connect2 to="Government.today_1" from="Climate.today"/>
 				<connect to="Government.Total_nominal_SLR_protection_cost" from="Sea_level_rise_costs_and_impacts.Total_nominal_SLR_protection_cost"/>
 				<connect2 to="Government.Total_nominal_SLR_protection_cost" from="Sea_level_rise_costs_and_impacts.Total_nominal_SLR_protection_cost"/>
 				<connect to="Government.unemployment_goal_policy" from="Government_Regulations.unemployment_goal_policy"/>
@@ -578,6 +582,8 @@
 				<connect2 to="Circular_Flow.time_to_implement_tax_policy" from="Government_Regulations.time_to_implement_tax_policy"/>
 				<connect to="Circular_Flow.Total_nominal_people_retreat_costs" from="Sea_level_rise_costs_and_impacts.Total_nominal_people_retreat_costs"/>
 				<connect2 to="Circular_Flow.Total_nominal_people_retreat_costs" from="Sea_level_rise_costs_and_impacts.Total_nominal_people_retreat_costs"/>
+				<connect to="Circular_Flow.UNIT_Percent" from="Inflation.UNIT_Percent"/>
+				<connect2 to="Circular_Flow.UNIT_Percent" from="Inflation.UNIT_Percent"/>
 				<connect to="Circular_Flow.wage_tax_policy" from="Government_Regulations.wage_tax_rate_policy"/>
 				<connect2 to="Circular_Flow.wage_tax_policy" from="Government_Regulations.wage_tax_rate_policy"/>
 				<connect to="Circular_Flow.wealth_taxation_rate" from="Government_Regulations.wealth_tax_policy"/>
@@ -795,6 +801,8 @@
 				<connect2 to='Government."inflation_adjustment_b$_per_bc$"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
 				<connect to='Government."inflation_adjustment_b$_per_bc$_1"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
 				<connect2 to='Government."inflation_adjustment_b$_per_bc$_1"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
+				<connect to='Government."inflation_adjustment_b$_per_bc$_2"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
+				<connect2 to='Government."inflation_adjustment_b$_per_bc$_2"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
 				<connect to='Sea_level_rise_costs_and_impacts."inflation_adjustment_b$_per_bc$"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
 				<connect2 to='Sea_level_rise_costs_and_impacts."inflation_adjustment_b$_per_bc$"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
 				<connect to='Sea_level_rise_costs_and_impacts."inflation_adjustment_b$_per_bc$_1"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
@@ -805,6 +813,8 @@
 				<connect2 to="Circular_Flow.Inflation_Rate" from="Inflation.Inflation_Rate"/>
 				<connect to="Government.inflation" from="Inflation.Inflation_Rate"/>
 				<connect2 to="Government.inflation" from="Inflation.Inflation_Rate"/>
+				<connect to="Circular_Flow.UNIT_Percent" from="Inflation.UNIT_Percent"/>
+				<connect2 to="Circular_Flow.UNIT_Percent" from="Inflation.UNIT_Percent"/>
 				<connect to="Employment.UNIT_Percent" from="Inflation.UNIT_Percent"/>
 				<connect2 to="Employment.UNIT_Percent" from="Inflation.UNIT_Percent"/>
 				<connect to="Inflation.animal_products_demand" from="Food_Demand.animal_products_demand"/>
@@ -976,7 +986,7 @@
 				<isee:iframe color="black" background="white" text_align="left" vertical_text_align="top" font_size="12pt" border_width="thin" border_style="solid"/>
 				<isee:financial_table color="black" background="#E0E0E0" text_align="right" font_size="12pt" hide_border="false" auto_fit="true" first_column_width="250" other_column_width="100" header_font_style="normal" header_font_weight="bold" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="14pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 			</style>
-			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="2" isee:page_rows="2" isee:scroll_x="240.714" isee:scroll_y="62.1429" zoom="140" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
+			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="2" isee:page_rows="2" isee:scroll_x="240" isee:scroll_y="105" zoom="140" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
 				<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
 					<stock color="blue" background="white" font_color="blue" font_size="12.51pt" label_side="top">
 						<shape type="rectangle" width="45" height="35"/>
@@ -2069,6 +2079,24 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 				<eqn>&quot;rent_in_in_2021c$&quot;-&quot;rent_tax_in_2021c$&quot;</eqn>
 				<units>bc$/year</units>
 			</aux>
+			<aux name="net income">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>net_owner_income+net_worker_income</eqn>
+				<units>b$/year</units>
+			</aux>
+			<aux name="worker share of net income">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>net_worker_income/net_income*UNIT_Percent</eqn>
+				<units>%</units>
+			</aux>
+			<aux name="UNIT Percent" access="input">
+				<eqn>100</eqn>
+				<units>%</units>
+			</aux>
 		</variables>
 		<views>
 			<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
@@ -2118,7 +2146,7 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 				<isee:iframe color="black" background="white" text_align="left" vertical_text_align="top" font_size="12pt" border_width="thin" border_style="solid"/>
 				<isee:financial_table color="black" background="#E0E0E0" text_align="right" font_size="12pt" hide_border="false" auto_fit="true" first_column_width="250" other_column_width="100" header_font_style="normal" header_font_weight="bold" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="14pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 			</style>
-			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="3" isee:page_rows="4" isee:scroll_x="515" isee:scroll_y="300" zoom="80" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
+			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="3" isee:page_rows="4" isee:scroll_x="635" isee:scroll_y="1249.29" zoom="140" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
 				<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
 					<stock color="blue" background="white" font_color="blue" font_size="11pt" label_side="top">
 						<shape type="rectangle" width="45" height="35"/>
@@ -2693,14 +2721,14 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 					<from>sum_of_subsidies_spent</from>
 					<to>government_spending</to>
 				</connector>
-				<aux x="1143.25" y="1727.25" name="income inequality"/>
+				<aux x="1103.96" y="1790.11" name="income inequality"/>
 				<connector uid="125" angle="299.358">
 					<from>
 						<alias uid="126"/>
 					</from>
 					<to>income_inequality</to>
 				</connector>
-				<connector uid="127" angle="235.222">
+				<connector uid="127" angle="226.219">
 					<from>
 						<alias uid="128"/>
 					</from>
@@ -3160,6 +3188,35 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 					<from>&quot;bank_profits_in_2021c$&quot;</from>
 					<to>&quot;bank_profits_after_tax_in_2021c$&quot;</to>
 				</connector>
+				<aux x="1103.96" y="1641.43" name="net income"/>
+				<connector uid="244" angle="66.8511">
+					<from>
+						<alias uid="126"/>
+					</from>
+					<to>net_income</to>
+				</connector>
+				<connector uid="245" angle="134.873">
+					<from>
+						<alias uid="128"/>
+					</from>
+					<to>net_income</to>
+				</connector>
+				<aux x="1162.11" y="1593.25" name="worker share of net income"/>
+				<connector uid="246" angle="39.646">
+					<from>net_income</from>
+					<to>worker_share_of_net_income</to>
+				</connector>
+				<connector uid="247" angle="94.9697">
+					<from>
+						<alias uid="128"/>
+					</from>
+					<to>worker_share_of_net_income</to>
+				</connector>
+				<aux font_style="italic" font_weight="bold" x="1031.43" y="1613.57" name="UNIT Percent"/>
+				<connector uid="248" angle="9.2726">
+					<from>UNIT_Percent</from>
+					<to>worker_share_of_net_income</to>
+				</connector>
 				<alias label_side="top" uid="8" x="2025" y="1070.87" width="18" height="18">
 					<of>time_to_reach_savings_goal</of>
 				</alias>
@@ -3256,10 +3313,10 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 				<alias font_style="italic" label_side="right" uid="118" x="1296.25" y="1871.25" width="18" height="18">
 					<of>firms_paying_interest</of>
 				</alias>
-				<alias font_style="italic" uid="126" x="1088.25" y="1647.25" width="18" height="18">
+				<alias font_style="italic" uid="126" x="1048.96" y="1710.11" width="18" height="18">
 					<of>net_owner_income</of>
 				</alias>
-				<alias font_style="italic" uid="128" x="1203.25" y="1646.25" width="18" height="18">
+				<alias font_style="italic" uid="128" x="1163.96" y="1709.11" width="18" height="18">
 					<of>net_worker_income</of>
 				</alias>
 				<alias font_style="italic" font_weight="bold" uid="140" x="269.25" y="1093" width="18" height="18">
@@ -4576,7 +4633,7 @@ effect_of_climate_on_high_exposure_labour
 				<isee:iframe color="black" background="white" text_align="left" vertical_text_align="top" font_size="12pt" border_width="thin" border_style="solid"/>
 				<isee:financial_table color="black" background="#E0E0E0" text_align="right" font_size="12pt" hide_border="false" auto_fit="true" first_column_width="250" other_column_width="100" header_font_style="normal" header_font_weight="bold" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="14pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 			</style>
-			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="6" isee:page_rows="6" isee:scroll_x="1196" isee:scroll_y="941" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
+			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="6" isee:page_rows="6" isee:scroll_x="318" isee:scroll_y="941" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
 				<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
 					<stock color="blue" background="white" font_color="blue" font_size="11pt" label_side="top">
 						<shape type="rectangle" width="45" height="35"/>
@@ -9563,6 +9620,62 @@ https://www.oecd-ilibrary.org/sites/e2ee1eb1-en/index.html?itemId=/content/compo
 				<eqn>1000000</eqn>
 				<units>p/Mp</units>
 			</aux>
+			<aux name="today 1" access="input">
+				<eqn>2025</eqn>
+				<units>year</units>
+			</aux>
+			<aux name="effect of STA on public consumption\ntoday">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>IF TIME &gt; today_1 THEN
+HISTORY(effect_of_STA_on_public_consumption, today_1)
+ELSE
+effect_of_STA_on_public_consumption</eqn>
+				<units>1</units>
+			</aux>
+			<aux name="government from STA impact">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>government_consumption*(effect_of_STA_on_public_consumption_today-1)</eqn>
+				<units>b$/year</units>
+			</aux>
+			<aux name="government spending\nbecause of climate">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>government_from_STA_impact+Total_nominal_SLR_protection_cost</eqn>
+				<units>b$/year</units>
+			</aux>
+			<aux name="government spending because of climate in 2021c$">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>government_spending_because_of_climate/&quot;inflation_adjustment_b$_per_bc$_2&quot;</eqn>
+				<units>bc$/year</units>
+			</aux>
+			<aux name="inflation adjustment b$ per bc$ 2" access="input">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>{Enter equation for use when not hooked up to other models}</eqn>
+				<units>b$/bc$</units>
+			</aux>
+			<aux name="government spending\nwithout climate impact">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>government_consumption-government_spending_because_of_climate</eqn>
+				<units>b$/year</units>
+			</aux>
+			<aux name="government spending\nwithout climate impact in 2021c$">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>government_spending_without_climate_impact/&quot;inflation_adjustment_b$_per_bc$_2&quot;</eqn>
+				<units>bc$/year</units>
+			</aux>
 		</variables>
 		<views>
 			<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
@@ -9612,7 +9725,7 @@ https://www.oecd-ilibrary.org/sites/e2ee1eb1-en/index.html?itemId=/content/compo
 				<isee:iframe color="black" background="white" text_align="left" vertical_text_align="top" font_size="12pt" border_width="thin" border_style="solid"/>
 				<isee:financial_table color="black" background="#E0E0E0" text_align="right" font_size="12pt" hide_border="false" auto_fit="true" first_column_width="250" other_column_width="100" header_font_style="normal" header_font_weight="bold" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="14pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 			</style>
-			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="3" isee:page_rows="4" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
+			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="3" isee:page_rows="4" isee:scroll_x="36.25" isee:scroll_y="1423.13" zoom="160" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
 				<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
 					<stock color="blue" background="white" font_color="blue" font_size="11pt" label_side="top">
 						<shape type="rectangle" width="45" height="35"/>
@@ -9678,7 +9791,7 @@ https://www.oecd-ilibrary.org/sites/e2ee1eb1-en/index.html?itemId=/content/compo
 				<aux label_side="top" x="257.14" y="165.667" name="normal public\nconsumption to transfers\nratio"/>
 				<aux label_side="right" x="926.429" y="245.167" name="initial government debt"/>
 				<aux label_side="left" x="765.13" y="1167.76" name="safe\ninterest"/>
-				<aux label_side="left" label_angle="135" x="284.14" y="370.2" name="government\nconsumption"/>
+				<aux label_side="top" x="284.14" y="370.2" name="government\nconsumption"/>
 				<connector uid="13" angle="127.806">
 					<from>public_expenditure_for_consumption_and_transfers</from>
 					<to>government_consumption</to>
@@ -10463,6 +10576,66 @@ https://www.oecd-ilibrary.org/sites/e2ee1eb1-en/index.html?itemId=/content/compo
 					<from>UNIT_p_per_mp</from>
 					<to>transfer_payments_per_recipient</to>
 				</connector>
+				<aux font_style="italic" font_weight="bold" x="57" y="401.92" name="today 1"/>
+				<aux x="149.875" y="352.2" name="effect of STA on public consumption\ntoday"/>
+				<connector uid="254" angle="239.076">
+					<from>effect_of_STA_on_public_consumption</from>
+					<to>effect_of_STA_on_public_consumption_today</to>
+				</connector>
+				<connector uid="255" angle="28.1621">
+					<from>today_1</from>
+					<to>effect_of_STA_on_public_consumption_today</to>
+				</connector>
+				<aux x="205" y="413.125" name="government from STA impact"/>
+				<connector uid="256" angle="289.168">
+					<from>effect_of_STA_on_public_consumption_today</from>
+					<to>government_from_STA_impact</to>
+				</connector>
+				<connector uid="257" angle="195.478">
+					<from>government_consumption</from>
+					<to>government_from_STA_impact</to>
+				</connector>
+				<aux x="284.14" y="449.375" name="government spending\nbecause of climate"/>
+				<connector uid="258" angle="328.392">
+					<from>government_from_STA_impact</from>
+					<to>government_spending_because_of_climate</to>
+				</connector>
+				<connector uid="260" angle="129.668">
+					<from>Total_nominal_SLR_protection_cost</from>
+					<to>government_spending_because_of_climate</to>
+				</connector>
+				<aux x="485" y="1747.5" name="government spending because of climate in 2021c$"/>
+				<aux font_style="italic" font_weight="bold" x="590" y="1895" name="inflation adjustment b$ per bc$ 2"/>
+				<connector uid="262" angle="125.446">
+					<from>&quot;inflation_adjustment_b$_per_bc$_2&quot;</from>
+					<to>&quot;government_spending_because_of_climate_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="263" angle="0">
+					<from>
+						<alias uid="261"/>
+					</from>
+					<to>&quot;government_spending_because_of_climate_in_2021c$&quot;</to>
+				</connector>
+				<aux x="343.857" y="499.2" name="government spending\nwithout climate impact"/>
+				<connector uid="264" angle="296.182">
+					<from>government_consumption</from>
+					<to>government_spending_without_climate_impact</to>
+				</connector>
+				<connector uid="265" angle="329.074">
+					<from>government_spending_because_of_climate</from>
+					<to>government_spending_without_climate_impact</to>
+				</connector>
+				<aux x="624.375" y="1751.25" name="government spending\nwithout climate impact in 2021c$"/>
+				<connector uid="266" angle="172.769">
+					<from>
+						<alias uid="267"/>
+					</from>
+					<to>&quot;government_spending_without_climate_impact_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="268" angle="76.5514">
+					<from>&quot;inflation_adjustment_b$_per_bc$_2&quot;</from>
+					<to>&quot;government_spending_without_climate_impact_in_2021c$&quot;</to>
+				</connector>
 				<alias font_style="italic" label_side="right" label_angle="315" uid="73" x="532.797" y="1275.5" width="18" height="18">
 					<of>baseline_interest</of>
 				</alias>
@@ -10481,6 +10654,14 @@ https://www.oecd-ilibrary.org/sites/e2ee1eb1-en/index.html?itemId=/content/compo
 				</alias>
 				<alias font_style="italic" uid="249" x="76" y="606" width="18" height="18">
 					<of>&quot;UNIT_c$_per_Bc$&quot;</of>
+				</alias>
+				<alias color="blue" background="white" font_style="italic" uid="261" x="329.75" y="1738.5" width="18" height="18">
+					<shape type="circle" radius="18"/>
+					<of>government_spending_because_of_climate</of>
+				</alias>
+				<alias color="blue" background="white" font_style="italic" uid="267" x="757.25" y="1760.25" width="18" height="18">
+					<shape type="circle" radius="18"/>
+					<of>government_spending_without_climate_impact</of>
 				</alias>
 			</view>
 		</views>

--- a/FRIDA_Modules/Economy.itmx
+++ b/FRIDA_Modules/Economy.itmx
@@ -822,7 +822,7 @@
 			<isee:placeholder name="Economy 2 Outputs">
 				<eqn>GDP.Nominal_GDP[1] + GDP.&quot;Real_GDP_in_2021c$&quot;[1] + Circular_Flow.private_consumption[1] + Government.government_consumption[1] + Finance.total_investment[1] + Employment.Employed[1] + Employment.Unemployed[1] + Employment.Wage_Rate[1] + Employment.unemployment_rate[1] + Government.debt_to_GDP_ratio[1]</eqn>
 			</isee:placeholder>
-			<module name="Sea level rise Impacts\nand Adaptation" isee:label="" url="/Users/bschoenberg/code/WorldTrans/Frida/FRIDA_Modules/Sea level rise Impacts and Adaptation.itmx">
+			<module name="Sea level rise Impacts\nand Adaptation" isee:label="" url="/Users/bschoenberg/code/WorldTrans/clones/me/WorldTransFRIDA/FRIDA_Modules/Sea level rise Impacts and Adaptation.itmx">
 				<format scale_by="auto"/>
 				<connect to="Sea_level_rise_Impacts_and_Adaptation.No_SLR_adaptation_strategy" from="Government_Regulations.No_SLR_adaptation_strategy"/>
 				<connect2 to="Sea_level_rise_Impacts_and_Adaptation.No_SLR_adaptation_strategy" from="Government_Regulations.No_SLR_adaptation_strategy"/>
@@ -7848,7 +7848,7 @@ ELSE 0</eqn>
 				<dimensions>
 					<dim name="Run"/>
 				</dimensions>
-				<eqn>Government_Debt*safe_interest</eqn>
+				<eqn>Government_Debt*average_government_debt_interest_rate</eqn>
 				<units>b$/year</units>
 			</aux>
 			<aux name="public expenditure\nfor consumption\nand transfers">
@@ -8641,6 +8641,17 @@ ELSE
 				<eqn>{Enter equation for use when not hooked up to other models}</eqn>
 				<units>year</units>
 			</aux>
+			<aux name="average government debt\ninterest rate">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>SMTH1(safe_interest, average_time_government_refinances_debt)</eqn>
+				<units>1/year</units>
+			</aux>
+			<aux name="average time government refinances debt">
+				<eqn>30</eqn>
+				<units>years</units>
+			</aux>
 		</variables>
 		<views>
 			<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
@@ -8690,7 +8701,7 @@ ELSE
 				<isee:iframe color="black" background="white" text_align="left" vertical_text_align="top" font_size="12pt" border_width="thin" border_style="solid"/>
 				<isee:financial_table color="black" background="#E0E0E0" text_align="right" font_size="12pt" hide_border="false" auto_fit="true" first_column_width="250" other_column_width="100" header_font_style="normal" header_font_weight="bold" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="14pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 			</style>
-			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="3" isee:page_rows="4" isee:scroll_x="292.143" isee:scroll_y="378.571" zoom="140" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
+			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="3" isee:page_rows="4" isee:scroll_x="292.143" isee:scroll_y="377.857" zoom="140" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
 				<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
 					<stock color="blue" background="white" font_color="blue" font_size="11pt" label_side="top">
 						<shape type="rectangle" width="45" height="35"/>
@@ -8754,12 +8765,8 @@ ELSE
 					<to>public_expenditure_for_consumption_and_transfers</to>
 				</connector>
 				<aux label_side="left" x="145.14" y="340.2" name="public\nconsumption to transfers\nratio"/>
-				<connector uid="11" angle="108.31">
-					<from>safe_interest</from>
-					<to>government_interest_payments</to>
-				</connector>
 				<aux label_side="right" x="83.429" y="38.1667" name="initial government debt"/>
-				<aux label_side="left" label_angle="135" x="589.726" y="776.759" name="safe\ninterest"/>
+				<aux label_side="left" x="618.13" y="846.759" name="safe\ninterest"/>
 				<aux label_side="left" label_angle="135" x="145.14" y="268.2" name="government\nconsumption"/>
 				<connector uid="12" angle="90">
 					<from>public_consumption_to_transfers_ratio</from>
@@ -8878,7 +8885,7 @@ ELSE
 					<from>inflation_target_discrepancy</from>
 					<to>interest_rate_policy_discrepancy</to>
 				</connector>
-				<connector uid="46" angle="67.6176">
+				<connector uid="46" angle="49.4867">
 					<from>Central_Bank_Safe_Interest</from>
 					<to>safe_interest</to>
 				</connector>
@@ -9464,6 +9471,20 @@ ELSE
 				<connector uid="228" angle="90">
 					<from>computed_government_debt_to_GDP_ratio_target</from>
 					<to>one_to_one_effect_of_debt_to_GDP_ratio_on_government_spending</to>
+				</connector>
+				<aux x="618.13" y="773.571" name="average government debt\ninterest rate"/>
+				<connector uid="229" angle="64.5202">
+					<from>safe_interest</from>
+					<to>average_government_debt_interest_rate</to>
+				</connector>
+				<connector uid="230" angle="149.419">
+					<from>average_government_debt_interest_rate</from>
+					<to>government_interest_payments</to>
+				</connector>
+				<aux x="731.714" y="785" name="average time government refinances debt"/>
+				<connector uid="231" angle="171.235">
+					<from>average_time_government_refinances_debt</from>
+					<to>average_government_debt_interest_rate</to>
 				</connector>
 				<alias font_style="italic" label_side="right" label_angle="315" uid="73" x="385.797" y="954.5" width="18" height="18">
 					<of>baseline_interest</of>

--- a/FRIDA_Modules/Economy.itmx
+++ b/FRIDA_Modules/Economy.itmx
@@ -437,6 +437,10 @@
 				<connect2 to="Government.required_last_resort_lending" from="Finance.required_government_solvency_support_lending"/>
 				<connect to="Government.start_year" from="Government_Regulations.start_year"/>
 				<connect2 to="Government.start_year" from="Government_Regulations.start_year"/>
+				<connect to="Government.Surface_Temperature_Anomaly" from="Energy_Balance_Model.Surface_Temperature_Anomaly"/>
+				<connect2 to="Government.Surface_Temperature_Anomaly" from="Energy_Balance_Model.Surface_Temperature_Anomaly"/>
+				<connect to="Government.switch_government_damage" from="Climate.switch_government_damage"/>
+				<connect2 to="Government.switch_government_damage" from="Climate.switch_government_damage"/>
 				<connect to="Government.tax_rate" from="wind_and_solar_energy.tax_rate"/>
 				<connect2 to="Government.tax_rate" from="wind_and_solar_energy.tax_rate"/>
 				<connect to="Government.tax_rate_1" from="hydropower_energy.tax_rate"/>
@@ -447,6 +451,8 @@
 				<connect2 to="Government.tax_rate_3" from="other_energy.tax_rate"/>
 				<connect to="Government.tax_rate_4" from="nuclear_energy.tax_rate"/>
 				<connect2 to="Government.tax_rate_4" from="nuclear_energy.tax_rate"/>
+				<connect to="Government.today" from="Climate.today"/>
+				<connect2 to="Government.today" from="Climate.today"/>
 				<connect to="Government.Total_nominal_SLR_protection_cost" from="Sea_level_rise_costs_and_impacts.Total_nominal_SLR_protection_cost"/>
 				<connect2 to="Government.Total_nominal_SLR_protection_cost" from="Sea_level_rise_costs_and_impacts.Total_nominal_SLR_protection_cost"/>
 				<connect to="Government.unemployment_goal_policy" from="Government_Regulations.unemployment_goal_policy"/>
@@ -932,7 +938,7 @@
 				<isee:iframe color="black" background="white" text_align="left" vertical_text_align="top" font_size="12pt" border_width="thin" border_style="solid"/>
 				<isee:financial_table color="black" background="#E0E0E0" text_align="right" font_size="12pt" hide_border="false" auto_fit="true" first_column_width="250" other_column_width="100" header_font_style="normal" header_font_weight="bold" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="14pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 			</style>
-			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="2" isee:page_rows="2" isee:scroll_x="150" isee:scroll_y="85.7143" zoom="140" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
+			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="2" isee:page_rows="2" isee:scroll_x="215.714" isee:scroll_y="578.571" zoom="140" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
 				<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
 					<stock color="blue" background="white" font_color="blue" font_size="12.51pt" label_side="top">
 						<shape type="rectangle" width="45" height="35"/>
@@ -1247,7 +1253,7 @@
 			<aux name="desired savings\nas multiple of\nprofits">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>10.4396494727387</eqn>
+				<eqn>10.4077273956322</eqn>
 				<range min="2" max="20"/>
 				<units>Years</units>
 			</aux>
@@ -1271,14 +1277,14 @@ SMTH1(net_owner_income*desired_savings_as_multiple_of_profits, time_to_consider_
 			<aux name="time to consider desired savings">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>1.10340065679604</eqn>
+				<eqn>1.13033809640626</eqn>
 				<range min="1" max="10"/>
 				<units>Years</units>
 			</aux>
 			<aux name="time to reach\nsavings goal">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>4.93128551870947</eqn>
+				<eqn>4.94011266910846</eqn>
 				<range min="1" max="5"/>
 				<units>year</units>
 			</aux>
@@ -1353,7 +1359,7 @@ SMTH1((net_worker_income*desired_savings_as_multiple_of_wages), time_to_consider
 			<aux name="desired savings\nas multiple of\nwages">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>2.4496565045003</eqn>
+				<eqn>2.39396376489632</eqn>
 				<range min="1" max="5"/>
 				<units>Years</units>
 			</aux>
@@ -1402,7 +1408,7 @@ SMTH1((net_worker_income*desired_savings_as_multiple_of_wages), time_to_consider
 			<aux name="wage tax rate">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>0.193514822202657</eqn>
+				<eqn>0.18694250402234</eqn>
 				<range min="0.1" max="0.3"/>
 				<units>dmnl</units>
 			</aux>
@@ -1415,17 +1421,17 @@ SMTH1((net_worker_income*desired_savings_as_multiple_of_wages), time_to_consider
 				<units>b$/year</units>
 			</flow>
 			<aux name="initial owner savings">
-				<eqn>50010.8478217988</eqn>
+				<eqn>49992.9207926066</eqn>
 				<range min="30000" max="60000"/>
 				<units>b$</units>
 			</aux>
 			<aux name="initial firms\nchecking accounts">
-				<eqn>5305.85853916569</eqn>
+				<eqn>5285.21784462511</eqn>
 				<range min="4000" max="6000"/>
 				<units>b$</units>
 			</aux>
 			<aux name="initial worker savings">
-				<eqn>23759.9222538967</eqn>
+				<eqn>23760.8255188658</eqn>
 				<range min="20000" max="30000"/>
 				<units>b$</units>
 			</aux>
@@ -1457,7 +1463,7 @@ SMTH1((net_worker_income*desired_savings_as_multiple_of_wages), time_to_consider
 			<aux name="time to pay out profits">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>2.91185710869511</eqn>
+				<eqn>2.88343746478208</eqn>
 				<range min="1" max="5"/>
 				<units>year</units>
 			</aux>
@@ -1818,7 +1824,7 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 			<aux name="profit tax rate">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>0.331571456839155</eqn>
+				<eqn>0.334200836748505</eqn>
 				<range min="0" max="0.4"/>
 				<units>dmnl</units>
 			</aux>
@@ -2759,7 +2765,7 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 	<model name="Employment">
 		<variables>
 			<aux name="initial unemployment rate">
-				<eqn>0.0760501165190791</eqn>
+				<eqn>0.0755643034345932</eqn>
 				<range min="0.03" max="0.1"/>
 				<units>dmnl</units>
 			</aux>
@@ -2771,7 +2777,7 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 				<units>Mp</units>
 			</aux>
 			<aux name="Initial Wage Rate">
-				<eqn>6240.73545677396</eqn>
+				<eqn>6377.323338907</eqn>
 				<range min="2000" max="10000"/>
 				<units>$/p</units>
 			</aux>
@@ -3134,20 +3140,20 @@ https://rshiny.ilo.org/dataexplorer32/?id=UNE_2EAP_SEX_AGE_RT_A&amp;ref_area=X01
 				<units>dmnl</units>
 			</aux>
 			<aux name="time seeking\nemployees">
-				<eqn>1.41629280756711</eqn>
+				<eqn>1.41646370610199</eqn>
 				<units>year</units>
 			</aux>
 			<aux name="max change in\nfractional wage growth">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>0.116512056670808</eqn>
+				<eqn>0.116783227112931</eqn>
 				<range min="0" max="0.9"/>
 				<units>1/year</units>
 			</aux>
 			<aux name="labour force\nparticipation fixed">
 				<doc>${Calibration Parameter}
 https://rshiny.ilo.org/dataexplorer20/?id=EAP_2WAP_SEX_AGE_RT_A&amp;ref_area=X01&amp;sex=SEX_T&amp;classif1=AGE_AGGREGATE_TOTAL&amp;timefrom=1991</doc>
-				<eqn>63.9973665968967</eqn>
+				<eqn>63.9970214817038</eqn>
 				<range min="61.8" max="66"/>
 				<units>dmnl</units>
 			</aux>
@@ -3161,7 +3167,7 @@ https://rshiny.ilo.org/dataexplorer20/?id=EAP_2WAP_SEX_AGE_RT_A&amp;ref_area=X01
 			<aux name="hiring to\ninvestment\nratio">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>0.204839223969682</eqn>
+				<eqn>0.204783155637842</eqn>
 				<range min="0.1" max="0.75"/>
 				<units>dmnl</units>
 			</aux>
@@ -3758,7 +3764,7 @@ effect_of_climate_on_high_exposure_labour
 				<units>years</units>
 			</aux>
 			<aux name="threshold\nunemployment\nrate">
-				<eqn>0.0900877815739811</eqn>
+				<eqn>0.086433435862455</eqn>
 				<range min="0.04" max="0.15"/>
 				<units>dmnl</units>
 			</aux>
@@ -3770,7 +3776,7 @@ effect_of_climate_on_high_exposure_labour
 				<units>dmnl</units>
 			</aux>
 			<aux name="sensitivity\nof hiring to\nunemployment\nrate">
-				<eqn>1.85292398186416</eqn>
+				<eqn>2</eqn>
 				<range min="0.1" max="2"/>
 				<units>dmnl</units>
 			</aux>
@@ -3891,7 +3897,7 @@ effect_of_climate_on_high_exposure_labour
 				<units>b$/year</units>
 			</aux>
 			<aux name="max firing\npercentage">
-				<eqn>0.0366297733693123</eqn>
+				<eqn>0.0387472978824597</eqn>
 				<range min="0.03" max="0.1"/>
 				<units>1/year</units>
 			</aux>
@@ -5529,7 +5535,7 @@ furthermore. The structure that was previously decided on had the productivity g
 			<aux name="loan maturation\ntime">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>21.0399802981558</eqn>
+				<eqn>20.617689193585</eqn>
 				<range min="3" max="30"/>
 				<units>Years</units>
 			</aux>
@@ -5566,7 +5572,7 @@ furthermore. The structure that was previously decided on had the productivity g
 			<aux name="max change in lending\nstandards">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>0.108445387618137</eqn>
+				<eqn>0.110208464803566</eqn>
 				<range min="0" max="1"/>
 				<units>dmnl</units>
 			</aux>
@@ -5580,7 +5586,7 @@ furthermore. The structure that was previously decided on had the productivity g
 			<aux name="time to change\nlending standards">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>1.30439981245385</eqn>
+				<eqn>1.32439318389895</eqn>
 				<range min="0.5" max="1.5"/>
 				<units>year</units>
 			</aux>
@@ -5614,7 +5620,7 @@ furthermore. The structure that was previously decided on had the productivity g
 			<aux name="reporting\ndelay">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>0.973122384945736</eqn>
+				<eqn>0.970501818127761</eqn>
 				<range min="0.125" max="1"/>
 				<units>year</units>
 			</aux>
@@ -5643,7 +5649,7 @@ furthermore. The structure that was previously decided on had the productivity g
 			<aux name="normal\nfailure rate">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>0.0268253737531501</eqn>
+				<eqn>0.0263608480240371</eqn>
 				<range min="0.01" max="0.05"/>
 				<units>dmnl</units>
 			</aux>
@@ -5669,7 +5675,7 @@ furthermore. The structure that was previously decided on had the productivity g
 			<aux name="elasticity of\ndesired bank growth\nrate to changes in lending\nstandards">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>3.91664897271061</eqn>
+				<eqn>3.87925133874483</eqn>
 				<range min="1" max="10"/>
 				<units>dmnl</units>
 			</aux>
@@ -5720,14 +5726,14 @@ furthermore. The structure that was previously decided on had the productivity g
 			<aux name="max change\nin failure rate">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>0.0851379574870907</eqn>
+				<eqn>0.0870882124215539</eqn>
 				<range min="0.05" max="0.2"/>
 				<units>dmnl</units>
 			</aux>
 			<aux name="bank expectation\nformation time">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>2.09242131041338</eqn>
+				<eqn>2.02837858522691</eqn>
 				<range min="2" max="20"/>
 				<units>years</units>
 			</aux>
@@ -5748,14 +5754,14 @@ furthermore. The structure that was previously decided on had the productivity g
 			<aux name="elasticity of bankruptcy\nrate on risk premium">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>4.64485211561433</eqn>
+				<eqn>4.64260598748452</eqn>
 				<range min="0.5" max="10"/>
 				<units>dmnl</units>
 			</aux>
 			<aux name="initial risk premium">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>0.0146315205303861</eqn>
+				<eqn>0.0142989674085363</eqn>
 				<range min="0.01" max="0.05"/>
 				<units>1/year</units>
 			</aux>
@@ -5767,22 +5773,22 @@ furthermore. The structure that was previously decided on had the productivity g
 				<units>dmnl</units>
 			</aux>
 			<aux name="initial bank investment">
-				<eqn>3854.7144689448</eqn>
+				<eqn>3856.73880365</eqn>
 				<range min="3000" max="5000"/>
 				<units>b$/year</units>
 			</aux>
 			<aux name="initial good loans">
-				<eqn>8024.7844030256</eqn>
+				<eqn>8058.69576465125</eqn>
 				<range min="7500" max="8500"/>
 				<units>b$</units>
 			</aux>
 			<aux name="initial bad loans">
-				<eqn>203.410006247564</eqn>
+				<eqn>203.237898485807</eqn>
 				<range min="180" max="300"/>
 				<units>b$</units>
 			</aux>
 			<aux name="Initial safe assets">
-				<eqn>72489.5556339758</eqn>
+				<eqn>72484.663820795</eqn>
 				<range min="60000" max="100000"/>
 				<units>b$</units>
 			</aux>
@@ -5879,7 +5885,7 @@ furthermore. The structure that was previously decided on had the productivity g
 			<aux name="sensitivity of failure rate to\ninvestment to gdp ratio">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>0.0750508223682323</eqn>
+				<eqn>0.0744647304338059</eqn>
 				<range min="0.05" max="1"/>
 				<units>dmnl</units>
 			</aux>
@@ -5912,7 +5918,7 @@ ELSE
 				<dimensions>
 					<dim name="Run"/>
 				</dimensions>
-				<eqn>0.578387205555792</eqn>
+				<eqn>0.580538686229538</eqn>
 				<range min="0.1" max="1.1"/>
 				<units>1/deg C</units>
 			</aux>
@@ -5952,7 +5958,7 @@ ELSE
 				<units>b$</units>
 			</stock>
 			<aux name="max change in\nbank investment\nas fraction of normal">
-				<eqn>0.711160573127497</eqn>
+				<eqn>0.737223956501519</eqn>
 				<range min="0.1" max="1"/>
 				<units>dmnl</units>
 			</aux>
@@ -6098,7 +6104,7 @@ ELSE
 				<units>b$/year</units>
 			</flow>
 			<aux name="time for safe loans that will fail to actually fail">
-				<eqn>10.2034764534148</eqn>
+				<eqn>10.9051671011741</eqn>
 				<range min="3" max="30"/>
 				<units>years</units>
 			</aux>
@@ -6346,7 +6352,7 @@ ELSE
 				<units>dmnl/year</units>
 			</aux>
 			<aux name="initial bank investment growth rate">
-				<eqn>0.0682429758469568</eqn>
+				<eqn>0.0667618301431663</eqn>
 				<range min="0" max="0.1"/>
 				<units>1/year</units>
 			</aux>
@@ -6503,7 +6509,7 @@ ELSE 0</eqn>
 				<isee:iframe color="black" background="white" text_align="left" vertical_text_align="top" font_size="12pt" border_width="thin" border_style="solid"/>
 				<isee:financial_table color="black" background="#E0E0E0" text_align="right" font_size="12pt" hide_border="false" auto_fit="true" first_column_width="250" other_column_width="100" header_font_style="normal" header_font_weight="bold" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="14pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 			</style>
-			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="4" isee:page_rows="3" isee:scroll_x="2307.22" isee:scroll_y="293.333" zoom="180" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
+			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="4" isee:page_rows="3" isee:scroll_x="1445.56" isee:scroll_y="570" zoom="180" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
 				<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
 					<stock color="blue" background="white" font_color="blue" font_size="11pt" label_side="top">
 						<shape type="rectangle" width="45" height="35"/>
@@ -7870,14 +7876,14 @@ ELSE 0</eqn>
 			<aux name="public\nconsumption to transfers\nratio">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>0.70192269580969</eqn>
+				<eqn>0.700617024292858</eqn>
 				<range min="0.7" max="1"/>
 				<units>dmnl</units>
 			</aux>
 			<aux name="initial government debt" access="output" isee:autocreated="true">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>10000</eqn>
+				<eqn>10010.5686214296</eqn>
 				<range min="0" max="25000"/>
 				<units>B$</units>
 			</aux>
@@ -7905,7 +7911,7 @@ ELSE 0</eqn>
 			<aux name="GDP\nperception time">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>2.05247538692746</eqn>
+				<eqn>2.04806913280597</eqn>
 				<range min="1" max="3"/>
 				<units>Years</units>
 			</aux>
@@ -7923,18 +7929,18 @@ ELSE 0</eqn>
 				<eqn>public_expenditure_for_consumption_and_transfers*(1-public_consumption_to_transfers_ratio)+additional_transfers</eqn>
 				<units>b$/year</units>
 			</aux>
-			<aux name="investment share of\npublic expenditure">
+			<aux name="normal\ninvestment share of\npublic expenditure">
 				<doc>${Assumption,Calibration Parameter}
 https://www.oecd-ilibrary.org/sites/e2ee1eb1-en/index.html?itemId=/content/component/e2ee1eb1-en</doc>
-				<eqn>0.050430443239546</eqn>
-				<range min="0.04" max="0.16"/>
+				<eqn>0.0429705648368578</eqn>
+				<range min="0.03" max="0.16"/>
 				<units>dmnl</units>
 			</aux>
 			<aux name="public\ninvestment" access="output" isee:autocreated="true">
 				<dimensions>
 					<dim name="Run"/>
 				</dimensions>
-				<eqn>public_expenditure_before_subsidies*investment_share_of_public_expenditure</eqn>
+				<eqn>public_expenditure_before_subsidies*climate_adjusted_investment_share_of_public_expenditure</eqn>
 				<units>b$/year</units>
 			</aux>
 			<aux name="profit tax 1" access="input">
@@ -7968,7 +7974,7 @@ https://www.oecd-ilibrary.org/sites/e2ee1eb1-en/index.html?itemId=/content/compo
 			<aux name="averaging time to adjust tax based on income">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>2.56742482100196</eqn>
+				<eqn>2.56656888721063</eqn>
 				<range min="1" max="3"/>
 				<units>year</units>
 			</aux>
@@ -8025,7 +8031,7 @@ ELSE
 				<units>1/year</units>
 			</aux>
 			<aux name="initial safe interest">
-				<eqn>0.0307077853820425</eqn>
+				<eqn>0.0307759850399812</eqn>
 				<range min="0" max="0.2"/>
 				<units>1/year</units>
 			</aux>
@@ -8558,7 +8564,7 @@ government_interest_payments</eqn>
 			<aux name="maximum effect of debt to GDP\nratio on government spending">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>1.31</eqn>
+				<eqn>1.29529237433603</eqn>
 				<range min="1.2" max="1.5"/>
 				<units>dmnl</units>
 			</aux>
@@ -8652,6 +8658,46 @@ ELSE
 				<eqn>30</eqn>
 				<units>years</units>
 			</aux>
+			<aux name="Surface Temperature Anomaly" access="input">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>{Enter equation for use when not hooked up to other models}</eqn>
+				<units>deg C</units>
+			</aux>
+			<aux name="effect of STA\non public investment">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>IF (switch_government_damage=0) AND TIME &gt; today THEN
+PREVIOUS(SELF, 0)
+ELSE
+1+sensitivity_of_effect_of_sta_on_government_investment*(Surface_Temperature_Anomaly)</eqn>
+				<units>dmnl</units>
+			</aux>
+			<aux name="switch government damage" access="input">
+				<eqn>1</eqn>
+				<units>dmnl</units>
+			</aux>
+			<aux name="today" access="input">
+				<eqn>2025</eqn>
+				<units>year</units>
+			</aux>
+			<aux name="sensitivity of effect\nof sta on government investment">
+				<eqn>0.501330154510088</eqn>
+				<range min="0.1" max="1.1"/>
+				<units>1/deg C</units>
+			</aux>
+			<aux name="climate adjusted\ninvestment share of\npublic expenditure">
+				<doc>${Assumption,Calibration Parameter}
+https://www.oecd-ilibrary.org/sites/e2ee1eb1-en/index.html?itemId=/content/component/e2ee1eb1-en</doc>
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>normal_investment_share_of_public_expenditure*effect_of_STA_on_public_investment</eqn>
+				<range min="0.04" max="0.16"/>
+				<units>dmnl</units>
+			</aux>
 		</variables>
 		<views>
 			<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
@@ -8701,7 +8747,7 @@ ELSE
 				<isee:iframe color="black" background="white" text_align="left" vertical_text_align="top" font_size="12pt" border_width="thin" border_style="solid"/>
 				<isee:financial_table color="black" background="#E0E0E0" text_align="right" font_size="12pt" hide_border="false" auto_fit="true" first_column_width="250" other_column_width="100" header_font_style="normal" header_font_weight="bold" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="14pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 			</style>
-			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="3" isee:page_rows="4" isee:scroll_x="292.143" isee:scroll_y="377.857" zoom="140" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
+			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="3" isee:page_rows="4" isee:scroll_y="1" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
 				<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
 					<stock color="blue" background="white" font_color="blue" font_size="11pt" label_side="top">
 						<shape type="rectangle" width="45" height="35"/>
@@ -8740,22 +8786,22 @@ ELSE
 					</graph>
 					<table color="black" background="#E0E0E0" text_align="right" font_size="12pt" orientation="vertical" wrap_text="false" isee:auto_fit="true" isee:use_alternate_row_colors="false" isee:unlimited_table_length="false" blank_column_width="80" column_width="160" interval="1" report_balances="beginning" report_flows="instantaneous" header_font_style="normal" header_font_weight="normal" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="12pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 				</style>
-				<aux x="533.44" y="176.025" name="smoothed total\npublic tax income"/>
-				<aux label_side="right" x="365.05" y="322.2" name="proportion of taxes\nto public spending"/>
-				<flow label_side="right" x="672.14" y="176.025" name="government\ntaking up debt">
+				<aux x="690.13" y="296.025" name="smoothed total\npublic tax income"/>
+				<aux label_side="right" x="504.05" y="424.2" name="proportion of taxes\nto public spending"/>
+				<flow label_side="right" x="811.14" y="278.025" name="government\ntaking up debt">
 					<pts>
-						<pt x="672.14" y="115.63"/>
-						<pt x="672.14" y="227.42"/>
+						<pt x="811.14" y="217.63"/>
+						<pt x="811.14" y="329.42"/>
 					</pts>
 				</flow>
-				<stock label_side="bottom" x="672.14" y="244.92" name="Government\nDebt"/>
-				<aux label_side="left" label_angle="225" x="408.39" y="487.83" name="government\ninterest payments"/>
+				<stock label_side="bottom" x="811.14" y="346.92" name="Government\nDebt"/>
+				<aux label_side="left" label_angle="225" x="547.39" y="589.83" name="government\ninterest payments"/>
 				<connector uid="1" angle="293.133">
 					<from>Government_Debt</from>
 					<to>government_interest_payments</to>
 				</connector>
-				<aux label_side="right" x="201" y="340.2" name="public expenditure\nfor consumption\nand transfers"/>
-				<aux x="636.13" y="397.2" name="debt to\nGDP ratio"/>
+				<aux label_side="right" x="340" y="442.2" name="public expenditure\nfor consumption\nand transfers"/>
+				<aux x="775.13" y="499.2" name="debt to\nGDP ratio"/>
 				<connector uid="2" angle="288.026">
 					<from>Government_Debt</from>
 					<to>debt_to_GDP_ratio</to>
@@ -8764,10 +8810,10 @@ ELSE
 					<from>government_interest_payments</from>
 					<to>public_expenditure_for_consumption_and_transfers</to>
 				</connector>
-				<aux label_side="left" x="145.14" y="340.2" name="public\nconsumption to transfers\nratio"/>
-				<aux label_side="right" x="83.429" y="38.1667" name="initial government debt"/>
-				<aux label_side="left" x="618.13" y="846.759" name="safe\ninterest"/>
-				<aux label_side="left" label_angle="135" x="145.14" y="268.2" name="government\nconsumption"/>
+				<aux label_side="left" x="284.14" y="442.2" name="public\nconsumption to transfers\nratio"/>
+				<aux label_side="right" x="926.429" y="245.167" name="initial government debt"/>
+				<aux label_side="left" x="765.13" y="1167.76" name="safe\ninterest"/>
+				<aux label_side="left" label_angle="135" x="284.14" y="370.2" name="government\nconsumption"/>
 				<connector uid="12" angle="90">
 					<from>public_consumption_to_transfers_ratio</from>
 					<to>government_consumption</to>
@@ -8776,9 +8822,9 @@ ELSE
 					<from>public_expenditure_for_consumption_and_transfers</from>
 					<to>government_consumption</to>
 				</connector>
-				<aux label_side="right" x="598.97" y="324.42" name="perceived\nGDP"/>
-				<aux label_side="bottom" x="569.13" y="353.55" name="initial\nperceived GDP"/>
-				<aux label_side="left" label_angle="135" x="515.44" y="371.55" name="GDP\nperception time"/>
+				<aux label_side="right" x="737.97" y="426.42" name="perceived\nGDP"/>
+				<aux label_side="bottom" x="708.13" y="455.55" name="initial\nperceived GDP"/>
+				<aux label_side="left" label_angle="135" x="654.44" y="473.55" name="GDP\nperception time"/>
 				<connector uid="14" angle="29.4329">
 					<from>GDP_perception_time</from>
 					<to>perceived_GDP</to>
@@ -8791,12 +8837,12 @@ ELSE
 					<from>perceived_GDP</from>
 					<to>debt_to_GDP_ratio</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" label_side="top" x="604.63" y="271.42" name="GDP"/>
+				<aux font_style="italic" font_weight="bold" label_side="top" x="743.63" y="373.42" name="GDP"/>
 				<connector uid="17" angle="263.904">
 					<from>GDP</from>
 					<to>perceived_GDP</to>
 				</connector>
-				<aux label_side="left" label_angle="225" x="145.14" y="417.42" name="government\ntransfers"/>
+				<aux label_side="left" label_angle="225" x="284.14" y="519.42" name="government\ntransfers"/>
 				<connector uid="18" angle="270">
 					<from>public_consumption_to_transfers_ratio</from>
 					<to>government_transfers</to>
@@ -8805,38 +8851,34 @@ ELSE
 					<from>public_expenditure_for_consumption_and_transfers</from>
 					<to>government_transfers</to>
 				</connector>
-				<aux label_side="left" x="200" y="119.025" name="investment share of\npublic expenditure"/>
-				<aux label_side="left" x="200" y="176.025" name="public\ninvestment"/>
-				<connector uid="21" angle="270">
-					<from>investment_share_of_public_expenditure</from>
-					<to>public_investment</to>
-				</connector>
+				<aux label_side="left" x="316" y="77.3583" name="normal\ninvestment share of\npublic expenditure"/>
+				<aux label_side="left" x="339" y="278.025" name="public\ninvestment"/>
 				<connector uid="22" angle="270.349">
 					<from>public_investment</from>
 					<to>public_expenditure_for_consumption_and_transfers</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" x="302.5" y="74.1667" name="profit tax 1"/>
-				<aux font_style="italic" font_weight="bold" x="278.214" y="119.025" name="wage tax 1"/>
-				<aux font_style="italic" font_weight="bold" x="302.5" y="29.3583" name="rent tax 1"/>
-				<aux label_side="top" x="451.91" y="81.6667" name="total public tax income"/>
-				<connector uid="23" angle="356.039">
+				<aux font_style="italic" font_weight="bold" x="417.214" y="165.667" name="profit tax 1"/>
+				<aux font_style="italic" font_weight="bold" x="417.214" y="216.025" name="wage tax 1"/>
+				<aux font_style="italic" font_weight="bold" x="417.214" y="104.358" name="rent tax 1"/>
+				<aux label_side="top" x="590.91" y="183.667" name="total public tax income"/>
+				<connector uid="23" angle="350.793">
 					<from>rent_tax_1</from>
 					<to>total_public_tax_income</to>
 				</connector>
-				<connector uid="24" angle="8.1301">
+				<connector uid="24" angle="5.08738">
 					<from>profit_tax_1</from>
 					<to>total_public_tax_income</to>
 				</connector>
-				<connector uid="25" angle="31.8365">
+				<connector uid="25" angle="30.2511">
 					<from>wage_tax_1</from>
 					<to>total_public_tax_income</to>
 				</connector>
-				<connector uid="26" angle="334.381">
+				<connector uid="26" angle="334.999">
 					<from>total_public_tax_income</from>
 					<to>smoothed_total_public_tax_income</to>
 				</connector>
-				<aux label_side="top" x="537.44" y="56.1667" name="averaging time to adjust tax based on income"/>
-				<connector uid="27" angle="297.269">
+				<aux label_side="top" x="676.44" y="158.167" name="averaging time to adjust tax based on income"/>
+				<connector uid="27" angle="304.852">
 					<from>averaging_time_to_adjust_tax_based_on_income</from>
 					<to>smoothed_total_public_tax_income</to>
 				</connector>
@@ -8844,26 +8886,26 @@ ELSE
 					<from>total_public_tax_income</from>
 					<to>government_taking_up_debt</to>
 				</connector>
-				<aux label_side="right" x="610.833" y="70.8333" name="initial smoothed total public tax income"/>
-				<connector uid="29" angle="264.289">
+				<aux label_side="right" x="749.833" y="172.833" name="initial smoothed total public tax income"/>
+				<connector uid="29" angle="274.776">
 					<from>initial_smoothed_total_public_tax_income</from>
 					<to>smoothed_total_public_tax_income</to>
 				</connector>
-				<aux label_side="left" label_angle="135" x="215.41" y="775.333" name="central bank\ngoal inflation"/>
-				<aux label_side="bottom" x="215.41" y="839.667" name="inflation\ntarget\ndiscrepancy"/>
+				<aux label_side="left" label_angle="135" x="362.41" y="1096.33" name="central bank\ngoal inflation"/>
+				<aux label_side="bottom" x="362.41" y="1160.67" name="inflation\ntarget\ndiscrepancy"/>
 				<connector uid="30" angle="270">
 					<from>central_bank_goal_inflation</from>
 					<to>inflation_target_discrepancy</to>
 				</connector>
-				<stock label_side="top" x="582.226" y="941.596" name="Central Bank\nSafe Interest"/>
-				<flow label_side="left" label_angle="135" x="582.226" y="1004.18" name="change in\nsafe interest">
+				<stock label_side="top" x="729.226" y="1262.6" name="Central Bank\nSafe Interest"/>
+				<flow label_side="left" label_angle="135" x="729.226" y="1325.18" name="change in\nsafe interest">
 					<pts>
-						<pt x="582.226" y="1058.27"/>
-						<pt x="582.226" y="959.096"/>
+						<pt x="729.226" y="1379.27"/>
+						<pt x="729.226" y="1280.1"/>
 					</pts>
 				</flow>
-				<aux label_side="right" x="654.263" y="1052.6" name="central bank\ninterest rate\nreactivity"/>
-				<aux label_side="right" x="654.263" y="954.762" name="central bank\nadjustment time"/>
+				<aux label_side="right" x="801.263" y="1373.6" name="central bank\ninterest rate\nreactivity"/>
+				<aux label_side="right" x="801.263" y="1275.76" name="central bank\nadjustment time"/>
 				<connector uid="41" angle="214.451">
 					<from>central_bank_adjustment_time</from>
 					<to>change_in_safe_interest</to>
@@ -8876,7 +8918,7 @@ ELSE
 					<from>Central_Bank_Safe_Interest</from>
 					<to>change_in_safe_interest</to>
 				</connector>
-				<aux label_side="right" x="654.263" y="1004.18" name="baseline\ninterest"/>
+				<aux label_side="right" x="801.263" y="1325.18" name="baseline\ninterest"/>
 				<connector uid="44" angle="180">
 					<from>baseline_interest</from>
 					<to>change_in_safe_interest</to>
@@ -8889,21 +8931,21 @@ ELSE
 					<from>Central_Bank_Safe_Interest</from>
 					<to>safe_interest</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" x="87.9997" y="831.334" name="inflation"/>
+				<aux font_style="italic" font_weight="bold" x="235" y="1152.33" name="inflation"/>
 				<connector uid="47" angle="40.8819">
 					<from>inflation</from>
 					<to>inflation_target_discrepancy</to>
 				</connector>
-				<aux label_side="right" x="654.263" y="877.929" name="initial safe interest"/>
-				<aux label_side="top" x="215.41" y="1005.83" name="unemployment\ntarget discrepancy"/>
-				<aux label_side="left" label_angle="225" x="355" y="909.833" name="interest rate\npolicy discrepancy"/>
-				<aux label_side="right" x="215.41" y="1061.67" name="central bank goal\nunemployment"/>
+				<aux label_side="right" x="801.263" y="1198.93" name="initial safe interest"/>
+				<aux label_side="top" x="362.41" y="1326.83" name="unemployment\ntarget discrepancy"/>
+				<aux label_side="left" label_angle="225" x="502" y="1230.83" name="interest rate\npolicy discrepancy"/>
+				<aux label_side="right" x="362.41" y="1382.67" name="central bank goal\nunemployment"/>
 				<connector uid="64" angle="90">
 					<from>central_bank_goal_unemployment</from>
 					<to>unemployment_target_discrepancy</to>
 				</connector>
-				<aux label_side="top" x="336" y="840.667" name="unemployment\nweight"/>
-				<aux label_side="top" x="403.63" y="853.334" name="inflation\nweight"/>
+				<aux label_side="top" x="483" y="1161.67" name="unemployment\nweight"/>
+				<aux label_side="top" x="550.63" y="1174.33" name="inflation\nweight"/>
 				<connector uid="65" angle="229.281">
 					<from>inflation_weight</from>
 					<to>interest_rate_policy_discrepancy</to>
@@ -8916,13 +8958,13 @@ ELSE
 					<from>interest_rate_policy_discrepancy</from>
 					<to>change_in_safe_interest</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" x="91.833" y="972.667" name="unemployment rate 1"/>
+				<aux font_style="italic" font_weight="bold" x="238.833" y="1293.67" name="unemployment rate 1"/>
 				<connector uid="68" angle="5.5722">
 					<from>unemployment_rate_1</from>
 					<to>unemployment_target_discrepancy</to>
 				</connector>
-				<aux x="306.667" y="976.667" name="yearly\nunemployment target\ndiscrepancy"/>
-				<aux x="385.63" y="1034.17" name="time to measure\nunemployment"/>
+				<aux x="453.667" y="1297.67" name="yearly\nunemployment target\ndiscrepancy"/>
+				<aux x="532.63" y="1355.17" name="time to measure\nunemployment"/>
 				<connector uid="69" angle="153.97">
 					<from>time_to_measure_unemployment</from>
 					<to>yearly_unemployment_target_discrepancy</to>
@@ -8941,18 +8983,18 @@ ELSE
 					</from>
 					<to>interest_rate_policy_discrepancy</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" label_side="right" x="853.714" y="371.55" name="required last\nresort lending"/>
-				<flow label_side="top" x="762.32" y="248.241" name="bailouts">
+				<aux font_style="italic" font_weight="bold" label_side="right" x="992.714" y="473.55" name="required last\nresort lending"/>
+				<flow label_side="top" x="901.32" y="350.241" name="bailouts">
 					<pts>
-						<pt x="830" y="248.241"/>
-						<pt x="694.64" y="248.241"/>
+						<pt x="969" y="350.241"/>
+						<pt x="833.64" y="350.241"/>
 					</pts>
 				</flow>
-				<aux x="938.143" y="299.343" name="solvency support adjustment time"/>
-				<aux font_style="italic" font_weight="bold" x="215.41" y="1152" name="unemployment goal policy"/>
-				<aux font_style="italic" font_weight="bold" x="151" y="643" name="inflation goal policy"/>
-				<aux font_style="italic" font_weight="bold" x="121" y="905" name="start year"/>
-				<connector uid="76" angle="302.905">
+				<aux x="1077.14" y="401.343" name="solvency support adjustment time"/>
+				<aux font_style="italic" font_weight="bold" x="362.41" y="1473" name="unemployment goal policy"/>
+				<aux font_style="italic" font_weight="bold" x="344.41" y="986" name="inflation goal policy"/>
+				<aux font_style="italic" font_weight="bold" x="268" y="1226" name="start year"/>
+				<connector uid="76" angle="279.266">
 					<from>inflation_goal_policy</from>
 					<to>central_bank_goal_inflation</to>
 				</connector>
@@ -8968,31 +9010,31 @@ ELSE
 					<from>unemployment_goal_policy</from>
 					<to>central_bank_goal_unemployment</to>
 				</connector>
-				<aux x="1621.28" y="994.33" name="tax revenue on investments in\nsolar and wind energy capacity"/>
+				<aux x="1760.28" y="1096.33" name="tax revenue on investments in\nsolar and wind energy capacity"/>
 				<connector uid="80" angle="180">
 					<from>Investments_in_Solar_and_Wind_Energy_Capacity</from>
 					<to>tax_revenue_on_investments_in_solar_and_wind_energy_capacity</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" x="1841" y="994.33" name="Investments in\nSolar and Wind\nEnergy Capacity"/>
-				<aux font_style="italic" font_weight="bold" x="1454" y="994.33" name="tax rate"/>
+				<aux font_style="italic" font_weight="bold" x="1980" y="1096.33" name="Investments in\nSolar and Wind\nEnergy Capacity"/>
+				<aux font_style="italic" font_weight="bold" x="1593" y="1096.33" name="tax rate"/>
 				<connector uid="83" angle="0">
 					<from>tax_rate</from>
 					<to>tax_revenue_on_investments_in_solar_and_wind_energy_capacity</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" x="1840" y="314.75" name="Coal Investments in Fossil\nFuel Extraction Capital"/>
-				<aux font_style="italic" font_weight="bold" x="1840" y="416.75" name="Coal Investments in\nFossil Energy Capital"/>
-				<aux font_style="italic" font_weight="bold" x="1840" y="521.775" name="Oil\nInvestments in Fossil\nFuel Extraction Capital"/>
-				<aux font_style="italic" font_weight="bold" x="1840" y="632.67" name="Oil\nInvestments in\nFossil Energy Capital"/>
-				<aux font_style="italic" font_weight="bold" x="1840" y="746.3" name="Gas\nInvestments in Fossil\nFuel Extraction Capital"/>
-				<aux font_style="italic" font_weight="bold" x="1840" y="869.75" name="Gas\nInvestments in\nFossil Energy Capital"/>
-				<aux font_style="italic" font_weight="bold" x="1841" y="1118.75" name="Investments in\nHydropower\nEnergy capacity"/>
-				<aux font_style="italic" font_weight="bold" x="1841" y="1237.08" name="Investments in\nBiofuel Capacity"/>
-				<aux font_style="italic" font_weight="bold" x="1841" y="1346.75" name="Investments in\nOther Capacity"/>
-				<aux font_style="italic" font_weight="bold" x="1841" y="1457.42" name="Investments in\nNuclear Capacity"/>
-				<aux font_style="italic" font_weight="bold" x="1454" y="314.75" name="fuel extraction tax rate"/>
-				<aux font_style="italic" font_weight="bold" x="1454" y="416.75" name="energy conversion tax rate"/>
-				<aux x="1621.28" y="314.75" name="tax revenue on investments in\ncoal extraction"/>
-				<aux x="1621.28" y="416.75" name="tax revenue on investments in\ncoal energy conversion"/>
+				<aux font_style="italic" font_weight="bold" x="1979" y="416.75" name="Coal Investments in Fossil\nFuel Extraction Capital"/>
+				<aux font_style="italic" font_weight="bold" x="1979" y="518.75" name="Coal Investments in\nFossil Energy Capital"/>
+				<aux font_style="italic" font_weight="bold" x="1979" y="623.775" name="Oil\nInvestments in Fossil\nFuel Extraction Capital"/>
+				<aux font_style="italic" font_weight="bold" x="1979" y="734.67" name="Oil\nInvestments in\nFossil Energy Capital"/>
+				<aux font_style="italic" font_weight="bold" x="1979" y="848.3" name="Gas\nInvestments in Fossil\nFuel Extraction Capital"/>
+				<aux font_style="italic" font_weight="bold" x="1979" y="971.75" name="Gas\nInvestments in\nFossil Energy Capital"/>
+				<aux font_style="italic" font_weight="bold" x="1980" y="1220.75" name="Investments in\nHydropower\nEnergy capacity"/>
+				<aux font_style="italic" font_weight="bold" x="1980" y="1339.08" name="Investments in\nBiofuel Capacity"/>
+				<aux font_style="italic" font_weight="bold" x="1980" y="1448.75" name="Investments in\nOther Capacity"/>
+				<aux font_style="italic" font_weight="bold" x="1980" y="1559.42" name="Investments in\nNuclear Capacity"/>
+				<aux font_style="italic" font_weight="bold" x="1593" y="416.75" name="fuel extraction tax rate"/>
+				<aux font_style="italic" font_weight="bold" x="1593" y="518.75" name="energy conversion tax rate"/>
+				<aux x="1760.28" y="416.75" name="tax revenue on investments in\ncoal extraction"/>
+				<aux x="1760.28" y="518.75" name="tax revenue on investments in\ncoal energy conversion"/>
 				<connector uid="84" angle="4.76364">
 					<from>fuel_extraction_tax_rate</from>
 					<to>tax_revenue_on_investments_in_coal_extraction</to>
@@ -9009,14 +9051,14 @@ ELSE
 					<from>Coal_Investments_in_Fossil_Energy_Capital</from>
 					<to>tax_revenue_on_investments_in_coal_energy_conversion</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" x="1454" y="521.775" name="fuel extraction tax rate 1"/>
-				<aux font_style="italic" font_weight="bold" x="1454" y="632.67" name="energy conversion tax rate 1"/>
-				<aux font_style="italic" font_weight="bold" x="1454" y="746.3" name="fuel extraction tax rate 2"/>
-				<aux font_style="italic" font_weight="bold" x="1454" y="869.75" name="energy conversion tax rate 2"/>
-				<aux x="1621.28" y="521.775" name="tax revenue on investments in\noil extraction"/>
-				<aux x="1621.28" y="632.67" name="tax revenue on investments in\noil energy conversion"/>
-				<aux x="1621.28" y="746.3" name="tax revenue on investments in\ngas extraction"/>
-				<aux x="1621.28" y="869.75" name="tax revenue on investments in\ngas energy conversion"/>
+				<aux font_style="italic" font_weight="bold" x="1593" y="623.775" name="fuel extraction tax rate 1"/>
+				<aux font_style="italic" font_weight="bold" x="1593" y="734.67" name="energy conversion tax rate 1"/>
+				<aux font_style="italic" font_weight="bold" x="1593" y="848.3" name="fuel extraction tax rate 2"/>
+				<aux font_style="italic" font_weight="bold" x="1593" y="971.75" name="energy conversion tax rate 2"/>
+				<aux x="1760.28" y="623.775" name="tax revenue on investments in\noil extraction"/>
+				<aux x="1760.28" y="734.67" name="tax revenue on investments in\noil energy conversion"/>
+				<aux x="1760.28" y="848.3" name="tax revenue on investments in\ngas extraction"/>
+				<aux x="1760.28" y="971.75" name="tax revenue on investments in\ngas energy conversion"/>
 				<connector uid="88" angle="0">
 					<from>fuel_extraction_tax_rate_1</from>
 					<to>tax_revenue_on_investments_in_oil_extraction</to>
@@ -9049,14 +9091,14 @@ ELSE
 					<from>Gas_Investments_in_Fossil_Energy_Capital</from>
 					<to>tax_revenue_on_investments_in_gas_energy_conversion</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" x="1454" y="1118.75" name="tax rate 1"/>
-				<aux font_style="italic" font_weight="bold" x="1454" y="1237.08" name="tax rate 2"/>
-				<aux font_style="italic" font_weight="bold" x="1454" y="1346.75" name="tax rate 3"/>
-				<aux font_style="italic" font_weight="bold" x="1454" y="1457.42" name="tax rate 4"/>
-				<aux x="1621.28" y="1118.75" name="tax revenue on investments in\nhydropower energy capacity"/>
-				<aux x="1621.28" y="1237.08" name="tax revenue on investments in\nbio fuel energy capacity"/>
-				<aux x="1621.28" y="1346.75" name="tax revenue on investments in\nother energy capacity"/>
-				<aux x="1621.28" y="1457.42" name="tax revenue on investments in\nnuclear energy capacity"/>
+				<aux font_style="italic" font_weight="bold" x="1593" y="1220.75" name="tax rate 1"/>
+				<aux font_style="italic" font_weight="bold" x="1593" y="1339.08" name="tax rate 2"/>
+				<aux font_style="italic" font_weight="bold" x="1593" y="1448.75" name="tax rate 3"/>
+				<aux font_style="italic" font_weight="bold" x="1593" y="1559.42" name="tax rate 4"/>
+				<aux x="1760.28" y="1220.75" name="tax revenue on investments in\nhydropower energy capacity"/>
+				<aux x="1760.28" y="1339.08" name="tax revenue on investments in\nbio fuel energy capacity"/>
+				<aux x="1760.28" y="1448.75" name="tax revenue on investments in\nother energy capacity"/>
+				<aux x="1760.28" y="1559.42" name="tax revenue on investments in\nnuclear energy capacity"/>
 				<connector uid="96" angle="354.806">
 					<from>tax_rate_1</from>
 					<to>tax_revenue_on_investments_in_hydropower_energy_capacity</to>
@@ -9089,17 +9131,17 @@ ELSE
 					<from>Investments_in_Nuclear_Capacity</from>
 					<to>tax_revenue_on_investments_in_nuclear_energy_capacity</to>
 				</connector>
-				<aux x="1669.28" y="943.33" name="expenditure on subsidies for investments in\nsolar and wind\nenergy capacity"/>
-				<aux x="1669.28" y="263.75" name="expenditure on subsidies for investments in\ncoal extraction"/>
-				<aux x="1669.28" y="365.75" name="expenditure on subsidies for investments in\ncoal energy conversion"/>
-				<aux x="1669.28" y="470.775" name="expenditure on subsidies for investments in\noil extraction"/>
-				<aux x="1669.28" y="581.67" name="expenditure on subsidies for investments in\noil energy conversion"/>
-				<aux x="1669.28" y="695.3" name="expenditure on subsidies for investments in\ngas extraction"/>
-				<aux x="1669.28" y="818.75" name="expenditure on subsidies for investments in\ngas energy conversion"/>
-				<aux x="1669.28" y="1067.75" name="expenditure on subsidies for investments in\nhydropower energy capacity"/>
-				<aux x="1669.28" y="1188.92" name="expenditure on subsidies for investments in\nbio fuel energy capacity"/>
-				<aux x="1669.28" y="1295.75" name="expenditure on subsidies for investments in\nother energy capacity"/>
-				<aux x="1669.28" y="1406.42" name="expenditure on subsidies for investments in\nnuclear energy capacity"/>
+				<aux x="1808.28" y="1045.33" name="expenditure on subsidies for investments in\nsolar and wind\nenergy capacity"/>
+				<aux x="1808.28" y="365.75" name="expenditure on subsidies for investments in\ncoal extraction"/>
+				<aux x="1808.28" y="467.75" name="expenditure on subsidies for investments in\ncoal energy conversion"/>
+				<aux x="1808.28" y="572.775" name="expenditure on subsidies for investments in\noil extraction"/>
+				<aux x="1808.28" y="683.67" name="expenditure on subsidies for investments in\noil energy conversion"/>
+				<aux x="1808.28" y="797.3" name="expenditure on subsidies for investments in\ngas extraction"/>
+				<aux x="1808.28" y="920.75" name="expenditure on subsidies for investments in\ngas energy conversion"/>
+				<aux x="1808.28" y="1169.75" name="expenditure on subsidies for investments in\nhydropower energy capacity"/>
+				<aux x="1808.28" y="1290.92" name="expenditure on subsidies for investments in\nbio fuel energy capacity"/>
+				<aux x="1808.28" y="1397.75" name="expenditure on subsidies for investments in\nother energy capacity"/>
+				<aux x="1808.28" y="1508.42" name="expenditure on subsidies for investments in\nnuclear energy capacity"/>
 				<connector uid="104" angle="10.6197">
 					<from>fuel_extraction_tax_rate</from>
 					<to>expenditure_on_subsidies_for_investments_in_coal_extraction</to>
@@ -9188,27 +9230,27 @@ ELSE
 					<from>Investments_in_Nuclear_Capacity</from>
 					<to>expenditure_on_subsidies_for_investments_in_nuclear_energy_capacity</to>
 				</connector>
-				<aux x="1621.28" y="90.3333" name="sum of energy taxes in nominal terms"/>
-				<aux x="1669.28" y="46.5" name="sum of energy subsidies in nominal terms"/>
-				<aux x="1891.83" y="176.025" name="UNIT c$ per Bc$"/>
-				<connector uid="151" angle="311.186">
+				<aux x="1760.28" y="192.333" name="sum of energy taxes in nominal terms"/>
+				<aux x="1808.28" y="148.5" name="sum of energy subsidies in nominal terms"/>
+				<aux x="2030.83" y="278.025" name="UNIT c$ per Bc$"/>
+				<connector uid="151" angle="283.587">
 					<from>
 						<alias uid="150"/>
 					</from>
 					<to>total_public_tax_income</to>
 				</connector>
-				<aux x="1425" y="46.5" name="sum of subsidies spent"/>
+				<aux x="1564" y="148.5" name="sum of subsidies spent"/>
 				<connector uid="159" angle="179.489">
 					<from>sum_of_energy_subsidies_in_nominal_terms</from>
 					<to>sum_of_subsidies_spent</to>
 				</connector>
-				<aux x="1368.75" y="127.5" name="time to pay subsidies"/>
+				<aux x="1507.75" y="229.5" name="time to pay subsidies"/>
 				<connector uid="160" angle="43.8309">
 					<from>time_to_pay_subsidies</from>
 					<to>sum_of_subsidies_spent</to>
 				</connector>
-				<aux label_side="left" x="330.297" y="281.92" name="public expenditure before\nsubsidies"/>
-				<connector uid="161" angle="231.991">
+				<aux label_side="left" x="469.297" y="383.92" name="public expenditure before\nsubsidies"/>
+				<connector uid="161" angle="226.162">
 					<from>smoothed_total_public_tax_income</from>
 					<to>public_expenditure_before_subsidies</to>
 				</connector>
@@ -9228,7 +9270,7 @@ ELSE
 					<from>public_expenditure_before_subsidies</from>
 					<to>public_expenditure_for_consumption_and_transfers</to>
 				</connector>
-				<aux x="1621.28" y="181.923" name="sum of energy taxes in real terms"/>
+				<aux x="1760.28" y="283.923" name="sum of energy taxes in real terms"/>
 				<connector uid="169" angle="97.3524">
 					<from>tax_revenue_on_investments_in_nuclear_energy_capacity</from>
 					<to>sum_of_energy_taxes_in_real_terms</to>
@@ -9281,7 +9323,7 @@ ELSE
 					<from>sum_of_energy_taxes_in_real_terms</from>
 					<to>sum_of_energy_taxes_in_nominal_terms</to>
 				</connector>
-				<aux x="1669.28" y="138.739" name="sum of energy subsidies\nin real terms"/>
+				<aux x="1808.28" y="240.739" name="sum of energy subsidies\nin real terms"/>
 				<connector uid="183" angle="88.835">
 					<from>expenditure_on_subsidies_for_investments_in_nuclear_energy_capacity</from>
 					<to>sum_of_energy_subsidies_in_real_terms</to>
@@ -9334,26 +9376,26 @@ ELSE
 					<from>sum_of_energy_subsidies_in_real_terms</from>
 					<to>sum_of_energy_subsidies_in_nominal_terms</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" x="1877.22" y="63.3333" name="inflation adjustment b$ per bc$"/>
-				<connector uid="197" angle="194.265">
+				<aux font_style="italic" font_weight="bold" x="2016.22" y="165.333" name="inflation adjustment b$ per bc$"/>
+				<connector uid="197" angle="186.022">
 					<from>&quot;inflation_adjustment_b$_per_bc$&quot;</from>
 					<to>sum_of_energy_taxes_in_nominal_terms</to>
 				</connector>
-				<connector uid="198" angle="173.758">
+				<connector uid="198" angle="175.372">
 					<from>&quot;inflation_adjustment_b$_per_bc$&quot;</from>
 					<to>sum_of_energy_subsidies_in_nominal_terms</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" x="222.857" y="515" name="Total nominal SLR\nprotection cost"/>
-				<stacked_container uid="200" x="915.714" y="585">
+				<aux font_style="italic" font_weight="bold" x="361.857" y="617" name="Total nominal SLR\nprotection cost"/>
+				<stacked_container uid="200" x="1062.71" y="906">
 					<graph width="350" height="250" comparative="true" type="time_series" show_grid="false" isee:tick_type="none" include_units_in_legend="false" plot_numbers="false" isee:label_pie_slices="false" isee:show_pie_borders="true" num_x_grid_lines="0" num_y_grid_lines="0" num_x_labels="5" num_y_labels="3" isee:fill_intensity="0.1" isee:allow_zero_axis="true" left_axis_multi_scale="false" left_axis_auto_scale="true" left_include_units="true" right_axis_multi_scale="false" right_axis_auto_scale="true" right_include_units="true">
 						<plot color="blue" isee:keep_zero_visible="false" pen_width="1" index="0" show_y_axis="true">
 							<entity name="debt_to_GDP_ratio[1]"/>
 						</plot>
 					</graph>
 				</stacked_container>
-				<aux x="492.91" y="427.116" name="effect of debt to GDP\nratio on government\nspending"/>
-				<aux x="354" y="543" name="maximum effect of debt to GDP\nratio on government spending"/>
-				<aux x="561.297" y="578.714" name="minimum effect of debt to GDP\nratio on government spending"/>
+				<aux x="631.91" y="529.116" name="effect of debt to GDP\nratio on government\nspending"/>
+				<aux x="493" y="645" name="maximum effect of debt to GDP\nratio on government spending"/>
+				<aux x="700.297" y="680.714" name="minimum effect of debt to GDP\nratio on government spending"/>
 				<connector uid="201" angle="39.8362">
 					<from>maximum_effect_of_debt_to_GDP_ratio_on_government_spending</from>
 					<to>effect_of_debt_to_GDP_ratio_on_government_spending</to>
@@ -9362,7 +9404,7 @@ ELSE
 					<from>minimum_effect_of_debt_to_GDP_ratio_on_government_spending</from>
 					<to>effect_of_debt_to_GDP_ratio_on_government_spending</to>
 				</connector>
-				<aux x="640.64" y="515" name="curvature effect of debt to GDP\nratio on government\nspending"/>
+				<aux x="779.64" y="617" name="curvature effect of debt to GDP\nratio on government\nspending"/>
 				<connector uid="203" angle="149.252">
 					<from>curvature_effect_of_debt_to_GDP_ratio_on_government_spending</from>
 					<to>effect_of_debt_to_GDP_ratio_on_government_spending</to>
@@ -9375,13 +9417,13 @@ ELSE
 					<from>effect_of_debt_to_GDP_ratio_on_government_spending</from>
 					<to>proportion_of_taxes_to_public_spending</to>
 				</connector>
-				<aux x="492.91" y="672.33" name="one to one effect of debt to GDP ratio on government spending"/>
+				<aux x="631.91" y="774.33" name="one to one effect of debt to GDP ratio on government spending"/>
 				<connector uid="207" angle="90">
 					<from>one_to_one_effect_of_debt_to_GDP_ratio_on_government_spending</from>
 					<to>effect_of_debt_to_GDP_ratio_on_government_spending</to>
 				</connector>
-				<aux x="312.297" y="635.33" name="effect start effect of debt to GDP\nratio on government spending"/>
-				<aux x="252" y="596.714" name="effect end effect of debt to GDP\nratio on government spending"/>
+				<aux x="451.297" y="737.33" name="effect start effect of debt to GDP\nratio on government spending"/>
+				<aux x="391" y="698.714" name="effect end effect of debt to GDP\nratio on government spending"/>
 				<connector uid="208" angle="38.6888">
 					<from>effect_start_effect_of_debt_to_GDP_ratio_on_government_spending</from>
 					<to>effect_of_debt_to_GDP_ratio_on_government_spending</to>
@@ -9390,22 +9432,22 @@ ELSE
 					<from>effect_end_effect_of_debt_to_GDP_ratio_on_government_spending</from>
 					<to>effect_of_debt_to_GDP_ratio_on_government_spending</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" x="235.714" y="14.2857" name="wealth tax"/>
-				<connector uid="210" angle="2.2026">
+				<aux font_style="italic" font_weight="bold" x="417.214" y="56.2857" name="wealth tax"/>
+				<connector uid="210" angle="343.258">
 					<from>wealth_tax</from>
 					<to>total_public_tax_income</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" x="640.714" y="672.143" name="minimum percentage of taxes spent by government"/>
+				<aux font_style="italic" font_weight="bold" x="779.714" y="774.143" name="minimum percentage of taxes spent by government"/>
 				<connector uid="212" angle="134.397">
 					<from>minimum_percentage_of_taxes_spent_by_government</from>
 					<to>minimum_effect_of_debt_to_GDP_ratio_on_government_spending</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" x="755.891" y="379.2" name="bailouts 1"/>
+				<aux font_style="italic" font_weight="bold" x="894.891" y="481.2" name="bailouts 1"/>
 				<connector uid="215" angle="72.8598">
 					<from>bailouts_1</from>
 					<to>bank_bailouts</to>
 				</connector>
-				<aux x="773.891" y="320.836" name="bank bailouts"/>
+				<aux x="912.891" y="422.836" name="bank bailouts"/>
 				<connector uid="216" angle="147.571">
 					<from>required_last_resort_lending</from>
 					<to>bank_bailouts</to>
@@ -9418,12 +9460,12 @@ ELSE
 					<from>bank_bailouts</from>
 					<to>bailouts</to>
 				</connector>
-				<aux label_side="top" x="373" y="182.275" name="public\nexpenditure"/>
+				<aux label_side="top" x="512" y="284.275" name="public\nexpenditure"/>
 				<connector uid="199" angle="45">
 					<from>Total_nominal_SLR_protection_cost</from>
 					<to>public_expenditure</to>
 				</connector>
-				<connector uid="166" angle="12.0948">
+				<connector uid="166" angle="12.1298">
 					<from>
 						<alias uid="164"/>
 					</from>
@@ -9437,15 +9479,15 @@ ELSE
 					<from>public_expenditure</from>
 					<to>government_taking_up_debt</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" x="463.339" y="148.929" name="additional transfers policy"/>
-				<aux x="417.714" y="223.115" name="additional transfers"/>
+				<aux font_style="italic" font_weight="bold" x="605.857" y="251.167" name="additional transfers policy"/>
+				<aux x="556.714" y="325.115" name="additional transfers"/>
 				<connector uid="219" angle="130.162">
 					<from>
 						<alias uid="220"/>
 					</from>
 					<to>additional_transfers</to>
 				</connector>
-				<connector uid="221" angle="222.547">
+				<connector uid="221" angle="220.532">
 					<from>additional_transfers_policy</from>
 					<to>additional_transfers</to>
 				</connector>
@@ -9467,39 +9509,73 @@ ELSE
 					</from>
 					<to>minimum_effect_of_debt_to_GDP_ratio_on_government_spending</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" x="479.286" y="777.143" name="computed government debt to GDP ratio target"/>
+				<aux font_style="italic" font_weight="bold" x="618.286" y="879.143" name="computed government debt to GDP ratio target"/>
 				<connector uid="228" angle="90">
 					<from>computed_government_debt_to_GDP_ratio_target</from>
 					<to>one_to_one_effect_of_debt_to_GDP_ratio_on_government_spending</to>
 				</connector>
-				<aux x="618.13" y="773.571" name="average government debt\ninterest rate"/>
-				<connector uid="229" angle="64.5202">
+				<aux x="609.13" y="1074.57" name="average government debt\ninterest rate"/>
+				<connector uid="229" angle="123.668">
 					<from>safe_interest</from>
 					<to>average_government_debt_interest_rate</to>
 				</connector>
-				<connector uid="230" angle="149.419">
+				<connector uid="230" angle="120.398">
 					<from>average_government_debt_interest_rate</from>
 					<to>government_interest_payments</to>
 				</connector>
-				<aux x="731.714" y="785" name="average time government refinances debt"/>
-				<connector uid="231" angle="171.235">
+				<aux x="729.226" y="1034" name="average time government refinances debt"/>
+				<connector uid="231" angle="198.666">
 					<from>average_time_government_refinances_debt</from>
 					<to>average_government_debt_interest_rate</to>
 				</connector>
-				<alias font_style="italic" label_side="right" label_angle="315" uid="73" x="385.797" y="954.5" width="18" height="18">
+				<aux font_style="italic" font_weight="bold" x="84.1429" y="95.3583" name="Surface Temperature Anomaly"/>
+				<aux label_side="bottom" x="209.17" y="125.877" name="effect of STA\non public investment"/>
+				<connector uid="232" angle="346.283">
+					<from>Surface_Temperature_Anomaly</from>
+					<to>effect_of_STA_on_public_investment</to>
+				</connector>
+				<aux font_style="italic" font_weight="bold" x="121" y="34" name="switch government damage"/>
+				<aux font_style="italic" font_weight="bold" x="93" y="190.833" name="today"/>
+				<connector uid="233" angle="313.82">
+					<from>switch_government_damage</from>
+					<to>effect_of_STA_on_public_investment</to>
+				</connector>
+				<connector uid="234" angle="29.2117">
+					<from>today</from>
+					<to>effect_of_STA_on_public_investment</to>
+				</connector>
+				<aux x="146" y="260.025" name="sensitivity of effect\nof sta on government investment"/>
+				<connector uid="235" angle="64.7844">
+					<from>sensitivity_of_effect_of_sta_on_government_investment</from>
+					<to>effect_of_STA_on_public_investment</to>
+				</connector>
+				<aux label_side="left" x="313" y="208.833" name="climate adjusted\ninvestment share of\npublic expenditure"/>
+				<connector uid="236" angle="273.402">
+					<from>normal_investment_share_of_public_expenditure</from>
+					<to>climate_adjusted_investment_share_of_public_expenditure</to>
+				</connector>
+				<connector uid="237" angle="309.38">
+					<from>effect_of_STA_on_public_investment</from>
+					<to>climate_adjusted_investment_share_of_public_expenditure</to>
+				</connector>
+				<connector uid="238" angle="290.288">
+					<from>climate_adjusted_investment_share_of_public_expenditure</from>
+					<to>public_investment</to>
+				</connector>
+				<alias font_style="italic" label_side="right" label_angle="315" uid="73" x="532.797" y="1275.5" width="18" height="18">
 					<of>baseline_interest</of>
 				</alias>
-				<alias font_style="italic" uid="150" x="381.39" y="2.3583" width="18" height="18">
+				<alias font_style="italic" uid="150" x="544.857" y="21.3583" width="18" height="18">
 					<of>sum_of_energy_taxes_in_nominal_terms</of>
 				</alias>
-				<alias color="blue" background="white" font_style="italic" uid="164" x="272.25" y="178.5" width="18" height="18">
+				<alias color="blue" background="white" font_style="italic" uid="164" x="419.25" y="293.275" width="18" height="18">
 					<shape type="circle" radius="18"/>
 					<of>sum_of_subsidies_spent</of>
 				</alias>
-				<alias uid="220" x="488.44" y="257.241" width="18" height="18">
+				<alias uid="220" x="627.44" y="359.241" width="18" height="18">
 					<of>start_year</of>
 				</alias>
-				<alias font_style="italic" font_weight="bold" uid="226" x="423.857" y="592.429" width="18" height="18">
+				<alias font_style="italic" font_weight="bold" uid="226" x="562.857" y="694.429" width="18" height="18">
 					<of>start_year</of>
 				</alias>
 			</view>
@@ -9719,17 +9795,17 @@ agriculture_share_of_GDP_starting_point_determinant*EXP(agriculture_share_of_GDP
 				<units>dmnl</units>
 			</aux>
 			<aux name="Agriculture share\nof GDP\nintercept">
-				<eqn>3.29539612429132</eqn>
+				<eqn>3.27564892308116</eqn>
 				<range min="0" max="100"/>
 				<units>dmnl</units>
 			</aux>
 			<aux name="agriculture share\nof GDP slope">
-				<eqn>-2.31257195593821</eqn>
+				<eqn>-2.35890293591449</eqn>
 				<range min="-10" max="1"/>
 				<units>Million*Person*Years/b$</units>
 			</aux>
 			<aux name="agriculture share\nof GDP starting point determinant">
-				<eqn>19.9327670541321</eqn>
+				<eqn>19.9197721339394</eqn>
 				<range min="0" max="20"/>
 				<units>dmnl</units>
 			</aux>
@@ -9817,7 +9893,7 @@ agriculture_share_of_GDP_starting_point_determinant*EXP(agriculture_share_of_GDP
 				<units>1/year</units>
 			</aux>
 			<aux name="deflation\nadjustment time">
-				<eqn>8.7536370439616</eqn>
+				<eqn>8.73731173254651</eqn>
 				<range min="2" max="10"/>
 				<units>years</units>
 			</aux>
@@ -9856,7 +9932,7 @@ agriculture_share_of_GDP_starting_point_determinant*EXP(agriculture_share_of_GDP
 			<aux name="weight of marginal energy\ncost inflation">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>0.0197710612951293</eqn>
+				<eqn>0.0191740703232162</eqn>
 				<range min="0.01" max="2"/>
 				<units>dmnl</units>
 			</aux>
@@ -9884,7 +9960,7 @@ agriculture_share_of_GDP_starting_point_determinant*EXP(agriculture_share_of_GDP
 			<aux name="weight of cropland inflation contribution">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>0.105608837736276</eqn>
+				<eqn>0.10578219798937</eqn>
 				<range min="0.001" max="2"/>
 				<units>dmnl</units>
 			</aux>
@@ -9916,7 +9992,7 @@ agriculture_share_of_GDP_starting_point_determinant*EXP(agriculture_share_of_GDP
 			<aux name="weight of fertilizer used per unit of crop production">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>0.00277669676022887</eqn>
+				<eqn>0.00517984464743103</eqn>
 				<range min="0.001" max="2"/>
 				<units>dmnl</units>
 			</aux>
@@ -9944,7 +10020,7 @@ agriculture_share_of_GDP_starting_point_determinant*EXP(agriculture_share_of_GDP
 			<aux name="weight of grazing land inflation contribution">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>0.0557400606768769</eqn>
+				<eqn>0.0581251329560812</eqn>
 				<range min="0.001" max="2"/>
 				<units>dmnl</units>
 			</aux>
@@ -9976,17 +10052,17 @@ agriculture_share_of_GDP_starting_point_determinant*EXP(agriculture_share_of_GDP
 			<aux name="weight of irrigation water used per unit of crop production inflation contribution">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>0.0480266467081516</eqn>
+				<eqn>0.0490963843684165</eqn>
 				<range min="0.001" max="2"/>
 				<units>dmnl</units>
 			</aux>
 			<aux name="initial inflation index">
-				<eqn>0.406247892400984</eqn>
+				<eqn>0.418</eqn>
 				<range min="0.35" max="0.55"/>
 				<units>dmnl</units>
 			</aux>
 			<aux name="initial inflation rate">
-				<eqn>0.0297959456323969</eqn>
+				<eqn>0.0299278300352081</eqn>
 				<range min="0" max="0.1"/>
 				<units>1/year</units>
 			</aux>
@@ -10096,7 +10172,7 @@ agriculture_share_of_GDP_starting_point_determinant*EXP(agriculture_share_of_GDP
 				<isee:iframe color="black" background="white" text_align="left" vertical_text_align="top" font_size="12pt" border_width="thin" border_style="solid"/>
 				<isee:financial_table color="black" background="#E0E0E0" text_align="right" font_size="12pt" hide_border="false" auto_fit="true" first_column_width="250" other_column_width="100" header_font_style="normal" header_font_weight="bold" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="14pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 			</style>
-			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="3" isee:page_rows="3" isee:scroll_x="201" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
+			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="3" isee:page_rows="3" isee:scroll_x="342" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
 				<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
 					<stock color="blue" background="white" font_color="blue" font_size="11pt" label_side="top">
 						<shape type="rectangle" width="45" height="35"/>
@@ -10580,7 +10656,7 @@ agriculture_share_of_GDP_starting_point_determinant*EXP(agriculture_share_of_GDP
 			<aux name="normal time to decrease innovation orientation">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>10.0330707712392</eqn>
+				<eqn>10.0357410824043</eqn>
 				<range min="5" max="20"/>
 				<units>years</units>
 			</aux>
@@ -10652,7 +10728,7 @@ ELSE MAX(0, Firms_Innovation_Orientation//time_to_decrease_innovation_orientatio
 			<aux name="sensitivity of\nfirms innovation orientation\nto cash deceleration">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>1.00985548578139</eqn>
+				<eqn>1.01030673741853</eqn>
 				<range min="0" max="20"/>
 				<units>dmnl</units>
 			</aux>
@@ -10689,7 +10765,7 @@ ELSE MAX(0, Firms_Innovation_Orientation//time_to_decrease_innovation_orientatio
 			<aux name="sensitivity of innovation\ndecrease to cash growth">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>9.99238355490161</eqn>
+				<eqn>9.99468058962003</eqn>
 				<range min="0" max="20"/>
 				<units>dmnl</units>
 			</aux>

--- a/FRIDA_Modules/Economy.itmx
+++ b/FRIDA_Modules/Economy.itmx
@@ -389,6 +389,8 @@
 				<connect2 to="Government.Coal_Investments_in_Fossil_Fuel_Extraction_Capital" from="energy_investments.Coal_Gross_Investments_in_Fossil_Fuel_Extraction_Capital"/>
 				<connect to="Government.computed_government_debt_to_GDP_ratio_target" from="Government_Regulations.computed_government_debt_to_GDP_ratio_target"/>
 				<connect2 to="Government.computed_government_debt_to_GDP_ratio_target" from="Government_Regulations.computed_government_debt_to_GDP_ratio_target"/>
+				<connect to="Government.Employed" from="Employment.Employed"/>
+				<connect2 to="Government.Employed" from="Employment.Employed"/>
 				<connect to="Government.energy_conversion_tax_rate" from="fossil_energy_coal.energy_conversion_effective_tax_rate"/>
 				<connect2 to="Government.energy_conversion_tax_rate" from="fossil_energy_coal.energy_conversion_effective_tax_rate"/>
 				<connect to="Government.energy_conversion_tax_rate_1" from="fossil_energy_oil.energy_conversion_effective_tax_rate"/>
@@ -411,6 +413,8 @@
 				<connect2 to="Government.inflation" from="Inflation.Inflation_Rate"/>
 				<connect to='Government."inflation_adjustment_b$_per_bc$"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
 				<connect2 to='Government."inflation_adjustment_b$_per_bc$"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
+				<connect to='Government."inflation_adjustment_b$_per_bc$_1"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
+				<connect2 to='Government."inflation_adjustment_b$_per_bc$_1"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
 				<connect to="Government.inflation_goal_policy" from="Government_Regulations.inflation_goal_policy"/>
 				<connect2 to="Government.inflation_goal_policy" from="Government_Regulations.inflation_goal_policy"/>
 				<connect to="Government.Investments_in_Biofuel_Capacity" from="energy_investments.Gross_Investments_in_Biofuel_Capacity"/>
@@ -429,6 +433,8 @@
 				<connect2 to="Government.Oil_Investments_in_Fossil_Energy_Capital" from="energy_investments.Oil_Gross_Investments_in_Fossil_Energy_Capital"/>
 				<connect to="Government.Oil_Investments_in_Fossil_Fuel_Extraction_Capital" from="energy_investments.Oil_Gross_Investments_in_Fossil_Fuel_Extraction_Capital"/>
 				<connect2 to="Government.Oil_Investments_in_Fossil_Fuel_Extraction_Capital" from="energy_investments.Oil_Gross_Investments_in_Fossil_Fuel_Extraction_Capital"/>
+				<connect to="Government.Population" from="Demographics.Population"/>
+				<connect2 to="Government.Population" from="Demographics.Population"/>
 				<connect to="Government.profit_tax_1" from="Circular_Flow.profit_tax"/>
 				<connect2 to="Government.profit_tax_1" from="Circular_Flow.profit_tax"/>
 				<connect to="Government.rent_tax_1" from="Circular_Flow.rent_tax"/>
@@ -667,6 +673,8 @@
 				<format scale_by="auto"/>
 				<connect to="Circular_Flow.annual_aggregate_wages" from="Employment.annual_aggregate_wages"/>
 				<connect2 to="Circular_Flow.annual_aggregate_wages" from="Employment.annual_aggregate_wages"/>
+				<connect to="Government.Employed" from="Employment.Employed"/>
+				<connect2 to="Government.Employed" from="Employment.Employed"/>
 				<connect to="Inflation.Employed" from="Employment.Employed"/>
 				<connect2 to="Inflation.Employed" from="Employment.Employed"/>
 				<connect to="Sea_level_rise_costs_and_impacts.Employed" from="Employment.Employed"/>
@@ -737,6 +745,8 @@
 				<connect2 to="Employment.today" from="Climate.today"/>
 				<connect to="Employment.total_investment_1" from="Finance.total_investment"/>
 				<connect2 to="Employment.total_investment_1" from="Finance.total_investment"/>
+				<connect to="Employment.UNIT_Percent" from="Inflation.UNIT_Percent"/>
+				<connect2 to="Employment.UNIT_Percent" from="Inflation.UNIT_Percent"/>
 				<connect to="Employment.working_age_population_2" from="Demographics.working_age_population"/>
 				<connect2 to="Employment.working_age_population_2" from="Demographics.working_age_population"/>
 			</module>
@@ -759,6 +769,8 @@
 				<connect2 to='GDP."inflation_adjustment_b$_per_bc$"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
 				<connect to='Government."inflation_adjustment_b$_per_bc$"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
 				<connect2 to='Government."inflation_adjustment_b$_per_bc$"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
+				<connect to='Government."inflation_adjustment_b$_per_bc$_1"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
+				<connect2 to='Government."inflation_adjustment_b$_per_bc$_1"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
 				<connect to='Sea_level_rise_costs_and_impacts."inflation_adjustment_b$_per_bc$"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
 				<connect2 to='Sea_level_rise_costs_and_impacts."inflation_adjustment_b$_per_bc$"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
 				<connect to='Sea_level_rise_costs_and_impacts."inflation_adjustment_b$_per_bc$_1"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
@@ -769,6 +781,8 @@
 				<connect2 to="Circular_Flow.Inflation_Rate" from="Inflation.Inflation_Rate"/>
 				<connect to="Government.inflation" from="Inflation.Inflation_Rate"/>
 				<connect2 to="Government.inflation" from="Inflation.Inflation_Rate"/>
+				<connect to="Employment.UNIT_Percent" from="Inflation.UNIT_Percent"/>
+				<connect2 to="Employment.UNIT_Percent" from="Inflation.UNIT_Percent"/>
 				<connect to="Inflation.animal_products_demand" from="Food_Demand.animal_products_demand"/>
 				<connect2 to="Inflation.animal_products_demand" from="Food_Demand.animal_products_demand"/>
 				<connect to="Inflation.animal_products_production" from="Animal_Products.animal_products_production"/>
@@ -938,7 +952,7 @@
 				<isee:iframe color="black" background="white" text_align="left" vertical_text_align="top" font_size="12pt" border_width="thin" border_style="solid"/>
 				<isee:financial_table color="black" background="#E0E0E0" text_align="right" font_size="12pt" hide_border="false" auto_fit="true" first_column_width="250" other_column_width="100" header_font_style="normal" header_font_weight="bold" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="14pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 			</style>
-			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="2" isee:page_rows="2" isee:scroll_x="215.714" isee:scroll_y="578.571" zoom="140" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
+			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="2" isee:page_rows="2" isee:scroll_x="315.714" isee:scroll_y="19.2857" zoom="140" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
 				<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
 					<stock color="blue" background="white" font_color="blue" font_size="12.51pt" label_side="top">
 						<shape type="rectangle" width="45" height="35"/>
@@ -1253,7 +1267,7 @@
 			<aux name="desired savings\nas multiple of\nprofits">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>10.4077273956322</eqn>
+				<eqn>10.3987245416772</eqn>
 				<range min="2" max="20"/>
 				<units>Years</units>
 			</aux>
@@ -1277,14 +1291,14 @@ SMTH1(net_owner_income*desired_savings_as_multiple_of_profits, time_to_consider_
 			<aux name="time to consider desired savings">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>1.13033809640626</eqn>
+				<eqn>1.11496794322744</eqn>
 				<range min="1" max="10"/>
 				<units>Years</units>
 			</aux>
 			<aux name="time to reach\nsavings goal">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>4.94011266910846</eqn>
+				<eqn>4.9416051395598</eqn>
 				<range min="1" max="5"/>
 				<units>year</units>
 			</aux>
@@ -1359,7 +1373,7 @@ SMTH1((net_worker_income*desired_savings_as_multiple_of_wages), time_to_consider
 			<aux name="desired savings\nas multiple of\nwages">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>2.39396376489632</eqn>
+				<eqn>2.38287961093683</eqn>
 				<range min="1" max="5"/>
 				<units>Years</units>
 			</aux>
@@ -1408,7 +1422,7 @@ SMTH1((net_worker_income*desired_savings_as_multiple_of_wages), time_to_consider
 			<aux name="wage tax rate">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>0.18694250402234</eqn>
+				<eqn>0.178172140919826</eqn>
 				<range min="0.1" max="0.3"/>
 				<units>dmnl</units>
 			</aux>
@@ -1421,17 +1435,17 @@ SMTH1((net_worker_income*desired_savings_as_multiple_of_wages), time_to_consider
 				<units>b$/year</units>
 			</flow>
 			<aux name="initial owner savings">
-				<eqn>49992.9207926066</eqn>
+				<eqn>49959.3856161302</eqn>
 				<range min="30000" max="60000"/>
 				<units>b$</units>
 			</aux>
 			<aux name="initial firms\nchecking accounts">
-				<eqn>5285.21784462511</eqn>
+				<eqn>5268.43921063732</eqn>
 				<range min="4000" max="6000"/>
 				<units>b$</units>
 			</aux>
 			<aux name="initial worker savings">
-				<eqn>23760.8255188658</eqn>
+				<eqn>23749.583243234</eqn>
 				<range min="20000" max="30000"/>
 				<units>b$</units>
 			</aux>
@@ -1463,7 +1477,7 @@ SMTH1((net_worker_income*desired_savings_as_multiple_of_wages), time_to_consider
 			<aux name="time to pay out profits">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>2.88343746478208</eqn>
+				<eqn>2.89629752600508</eqn>
 				<range min="1" max="5"/>
 				<units>year</units>
 			</aux>
@@ -1824,7 +1838,7 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 			<aux name="profit tax rate">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>0.334200836748505</eqn>
+				<eqn>0.32957866625389</eqn>
 				<range min="0" max="0.4"/>
 				<units>dmnl</units>
 			</aux>
@@ -1893,7 +1907,7 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 				<isee:iframe color="black" background="white" text_align="left" vertical_text_align="top" font_size="12pt" border_width="thin" border_style="solid"/>
 				<isee:financial_table color="black" background="#E0E0E0" text_align="right" font_size="12pt" hide_border="false" auto_fit="true" first_column_width="250" other_column_width="100" header_font_style="normal" header_font_weight="bold" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="14pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 			</style>
-			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="3" isee:page_rows="3" isee:scroll_x="845" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
+			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="3" isee:page_rows="3" isee:scroll_x="476" isee:scroll_y="645" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
 				<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
 					<stock color="blue" background="white" font_color="blue" font_size="11pt" label_side="top">
 						<shape type="rectangle" width="45" height="35"/>
@@ -2765,7 +2779,7 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 	<model name="Employment">
 		<variables>
 			<aux name="initial unemployment rate">
-				<eqn>0.0755643034345932</eqn>
+				<eqn>0.0726045860738931</eqn>
 				<range min="0.03" max="0.1"/>
 				<units>dmnl</units>
 			</aux>
@@ -2777,7 +2791,7 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 				<units>Mp</units>
 			</aux>
 			<aux name="Initial Wage Rate">
-				<eqn>6377.323338907</eqn>
+				<eqn>6585.41895151817</eqn>
 				<range min="2000" max="10000"/>
 				<units>$/p</units>
 			</aux>
@@ -3140,20 +3154,20 @@ https://rshiny.ilo.org/dataexplorer32/?id=UNE_2EAP_SEX_AGE_RT_A&amp;ref_area=X01
 				<units>dmnl</units>
 			</aux>
 			<aux name="time seeking\nemployees">
-				<eqn>1.41646370610199</eqn>
+				<eqn>1.41657528041186</eqn>
 				<units>year</units>
 			</aux>
 			<aux name="max change in\nfractional wage growth">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>0.116783227112931</eqn>
+				<eqn>0.116784722900796</eqn>
 				<range min="0" max="0.9"/>
 				<units>1/year</units>
 			</aux>
 			<aux name="labour force\nparticipation fixed">
 				<doc>${Calibration Parameter}
 https://rshiny.ilo.org/dataexplorer20/?id=EAP_2WAP_SEX_AGE_RT_A&amp;ref_area=X01&amp;sex=SEX_T&amp;classif1=AGE_AGGREGATE_TOTAL&amp;timefrom=1991</doc>
-				<eqn>63.9970214817038</eqn>
+				<eqn>63.9980578246904</eqn>
 				<range min="61.8" max="66"/>
 				<units>dmnl</units>
 			</aux>
@@ -3167,7 +3181,7 @@ https://rshiny.ilo.org/dataexplorer20/?id=EAP_2WAP_SEX_AGE_RT_A&amp;ref_area=X01
 			<aux name="hiring to\ninvestment\nratio">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>0.204783155637842</eqn>
+				<eqn>0.204678633388394</eqn>
 				<range min="0.1" max="0.75"/>
 				<units>dmnl</units>
 			</aux>
@@ -3764,7 +3778,7 @@ effect_of_climate_on_high_exposure_labour
 				<units>years</units>
 			</aux>
 			<aux name="threshold\nunemployment\nrate">
-				<eqn>0.086433435862455</eqn>
+				<eqn>0.0852277255344759</eqn>
 				<range min="0.04" max="0.15"/>
 				<units>dmnl</units>
 			</aux>
@@ -3897,7 +3911,7 @@ effect_of_climate_on_high_exposure_labour
 				<units>b$/year</units>
 			</aux>
 			<aux name="max firing\npercentage">
-				<eqn>0.0387472978824597</eqn>
+				<eqn>0.0384381011022644</eqn>
 				<range min="0.03" max="0.1"/>
 				<units>1/year</units>
 			</aux>
@@ -3953,6 +3967,17 @@ effect_of_climate_on_high_exposure_labour
 				<eqn>{Enter equation for use when not hooked up to other models}</eqn>
 				<units>1/year</units>
 			</aux>
+			<aux name="UNIT Percent" access="input">
+				<eqn>100</eqn>
+				<units>%</units>
+			</aux>
+			<aux name="unemployment percentage">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>unemployment_rate*UNIT_Percent</eqn>
+				<units>%</units>
+			</aux>
 		</variables>
 		<views>
 			<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
@@ -4002,7 +4027,7 @@ effect_of_climate_on_high_exposure_labour
 				<isee:iframe color="black" background="white" text_align="left" vertical_text_align="top" font_size="12pt" border_width="thin" border_style="solid"/>
 				<isee:financial_table color="black" background="#E0E0E0" text_align="right" font_size="12pt" hide_border="false" auto_fit="true" first_column_width="250" other_column_width="100" header_font_style="normal" header_font_weight="bold" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="14pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 			</style>
-			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="6" isee:page_rows="6" isee:scroll_y="1228" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
+			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="6" isee:page_rows="6" isee:scroll_x="1196" isee:scroll_y="941" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
 				<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
 					<stock color="blue" background="white" font_color="blue" font_size="11pt" label_side="top">
 						<shape type="rectangle" width="45" height="35"/>
@@ -5312,6 +5337,16 @@ furthermore. The structure that was previously decided on had the productivity g
 					<to>indicated_productivity_growth</to>
 				</connector>
 				<aux font_style="italic" font_weight="bold" x="411" y="1392" name="bailouts as a share of maturing loans"/>
+				<aux font_style="italic" font_weight="bold" x="3041" y="1170" name="UNIT Percent"/>
+				<aux x="3147.65" y="1178" name="unemployment percentage"/>
+				<connector uid="275" angle="356.634">
+					<from>UNIT_Percent</from>
+					<to>unemployment_percentage</to>
+				</connector>
+				<connector uid="276" angle="293.066">
+					<from>unemployment_rate</from>
+					<to>unemployment_percentage</to>
+				</connector>
 				<alias color="blue" background="white" font_style="italic" label_side="left" uid="12" x="655.25" y="1050.17" width="18" height="18">
 					<shape type="circle" radius="18"/>
 					<of>wage_rate_in_billions_per_million_people</of>
@@ -5535,7 +5570,7 @@ furthermore. The structure that was previously decided on had the productivity g
 			<aux name="loan maturation\ntime">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>20.617689193585</eqn>
+				<eqn>20.6629336753641</eqn>
 				<range min="3" max="30"/>
 				<units>Years</units>
 			</aux>
@@ -5572,7 +5607,7 @@ furthermore. The structure that was previously decided on had the productivity g
 			<aux name="max change in lending\nstandards">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>0.110208464803566</eqn>
+				<eqn>0.109291004335017</eqn>
 				<range min="0" max="1"/>
 				<units>dmnl</units>
 			</aux>
@@ -5586,7 +5621,7 @@ furthermore. The structure that was previously decided on had the productivity g
 			<aux name="time to change\nlending standards">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>1.32439318389895</eqn>
+				<eqn>1.31756021795554</eqn>
 				<range min="0.5" max="1.5"/>
 				<units>year</units>
 			</aux>
@@ -5620,7 +5655,7 @@ furthermore. The structure that was previously decided on had the productivity g
 			<aux name="reporting\ndelay">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>0.970501818127761</eqn>
+				<eqn>0.969010531214806</eqn>
 				<range min="0.125" max="1"/>
 				<units>year</units>
 			</aux>
@@ -5649,7 +5684,7 @@ furthermore. The structure that was previously decided on had the productivity g
 			<aux name="normal\nfailure rate">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>0.0263608480240371</eqn>
+				<eqn>0.0269781701410859</eqn>
 				<range min="0.01" max="0.05"/>
 				<units>dmnl</units>
 			</aux>
@@ -5675,7 +5710,7 @@ furthermore. The structure that was previously decided on had the productivity g
 			<aux name="elasticity of\ndesired bank growth\nrate to changes in lending\nstandards">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>3.87925133874483</eqn>
+				<eqn>3.88911293916652</eqn>
 				<range min="1" max="10"/>
 				<units>dmnl</units>
 			</aux>
@@ -5726,14 +5761,14 @@ furthermore. The structure that was previously decided on had the productivity g
 			<aux name="max change\nin failure rate">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>0.0870882124215539</eqn>
+				<eqn>0.0912980819350005</eqn>
 				<range min="0.05" max="0.2"/>
 				<units>dmnl</units>
 			</aux>
 			<aux name="bank expectation\nformation time">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>2.02837858522691</eqn>
+				<eqn>2.69406180384551</eqn>
 				<range min="2" max="20"/>
 				<units>years</units>
 			</aux>
@@ -5754,14 +5789,14 @@ furthermore. The structure that was previously decided on had the productivity g
 			<aux name="elasticity of bankruptcy\nrate on risk premium">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>4.64260598748452</eqn>
+				<eqn>4.65072335676812</eqn>
 				<range min="0.5" max="10"/>
 				<units>dmnl</units>
 			</aux>
 			<aux name="initial risk premium">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>0.0142989674085363</eqn>
+				<eqn>0.0142763862308075</eqn>
 				<range min="0.01" max="0.05"/>
 				<units>1/year</units>
 			</aux>
@@ -5773,22 +5808,22 @@ furthermore. The structure that was previously decided on had the productivity g
 				<units>dmnl</units>
 			</aux>
 			<aux name="initial bank investment">
-				<eqn>3856.73880365</eqn>
+				<eqn>3856.10689399285</eqn>
 				<range min="3000" max="5000"/>
 				<units>b$/year</units>
 			</aux>
 			<aux name="initial good loans">
-				<eqn>8058.69576465125</eqn>
+				<eqn>8060.22030063522</eqn>
 				<range min="7500" max="8500"/>
 				<units>b$</units>
 			</aux>
 			<aux name="initial bad loans">
-				<eqn>203.237898485807</eqn>
+				<eqn>203.085182908877</eqn>
 				<range min="180" max="300"/>
 				<units>b$</units>
 			</aux>
 			<aux name="Initial safe assets">
-				<eqn>72484.663820795</eqn>
+				<eqn>72474.66800671</eqn>
 				<range min="60000" max="100000"/>
 				<units>b$</units>
 			</aux>
@@ -5885,7 +5920,7 @@ furthermore. The structure that was previously decided on had the productivity g
 			<aux name="sensitivity of failure rate to\ninvestment to gdp ratio">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>0.0744647304338059</eqn>
+				<eqn>0.0740210930882967</eqn>
 				<range min="0.05" max="1"/>
 				<units>dmnl</units>
 			</aux>
@@ -5918,7 +5953,7 @@ ELSE
 				<dimensions>
 					<dim name="Run"/>
 				</dimensions>
-				<eqn>0.580538686229538</eqn>
+				<eqn>0.580923481130727</eqn>
 				<range min="0.1" max="1.1"/>
 				<units>1/deg C</units>
 			</aux>
@@ -5958,7 +5993,7 @@ ELSE
 				<units>b$</units>
 			</stock>
 			<aux name="max change in\nbank investment\nas fraction of normal">
-				<eqn>0.737223956501519</eqn>
+				<eqn>0.552177625890471</eqn>
 				<range min="0.1" max="1"/>
 				<units>dmnl</units>
 			</aux>
@@ -6104,7 +6139,7 @@ ELSE
 				<units>b$/year</units>
 			</flow>
 			<aux name="time for safe loans that will fail to actually fail">
-				<eqn>10.9051671011741</eqn>
+				<eqn>10.9073255045334</eqn>
 				<range min="3" max="30"/>
 				<units>years</units>
 			</aux>
@@ -6352,7 +6387,7 @@ ELSE
 				<units>dmnl/year</units>
 			</aux>
 			<aux name="initial bank investment growth rate">
-				<eqn>0.0667618301431663</eqn>
+				<eqn>0.0675741761867058</eqn>
 				<range min="0" max="0.1"/>
 				<units>1/year</units>
 			</aux>
@@ -6372,7 +6407,7 @@ ELSE
 				<eqn>1</eqn>
 				<units>dmnl</units>
 			</aux>
-			<aux name="b$ to $">
+			<aux name="b$ to $" access="output" isee:autocreated="true">
 				<eqn>1000000000</eqn>
 				<units>$/b$</units>
 			</aux>
@@ -7678,7 +7713,7 @@ ELSE 0</eqn>
 				<isee:iframe color="black" background="white" text_align="left" vertical_text_align="top" font_size="12pt" border_width="thin" border_style="solid"/>
 				<isee:financial_table color="black" background="#E0E0E0" text_align="right" font_size="12pt" hide_border="false" auto_fit="true" first_column_width="250" other_column_width="100" header_font_style="normal" header_font_weight="bold" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="14pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 			</style>
-			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="2" isee:page_rows="2" isee:scroll_y="31.25" zoom="160" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
+			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="2" isee:page_rows="2" isee:scroll_y="106.25" zoom="160" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
 				<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
 					<stock color="blue" background="white" font_color="blue" font_size="11pt" label_side="top">
 						<shape type="rectangle" width="45" height="35"/>
@@ -7873,17 +7908,17 @@ ELSE 0</eqn>
 				<eqn>Government_Debt/perceived_GDP</eqn>
 				<units>year</units>
 			</aux>
-			<aux name="public\nconsumption to transfers\nratio">
+			<aux name="normal public\nconsumption to transfers\nratio">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>0.700617024292858</eqn>
-				<range min="0.7" max="1"/>
+				<eqn>0.669927358386248</eqn>
+				<range min="0.65" max="1"/>
 				<units>dmnl</units>
 			</aux>
 			<aux name="initial government debt" access="output" isee:autocreated="true">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>10010.5686214296</eqn>
+				<eqn>10013.0741244173</eqn>
 				<range min="0" max="25000"/>
 				<units>B$</units>
 			</aux>
@@ -7893,7 +7928,7 @@ ELSE 0</eqn>
 				<dimensions>
 					<dim name="Run"/>
 				</dimensions>
-				<eqn>public_expenditure_for_consumption_and_transfers*public_consumption_to_transfers_ratio</eqn>
+				<eqn>public_expenditure_for_consumption_and_transfers*climate_adjusted_public_consumption_to_transfers_ratio</eqn>
 				<units>b$/year</units>
 			</aux>
 			<aux name="perceived\nGDP">
@@ -7911,7 +7946,7 @@ ELSE 0</eqn>
 			<aux name="GDP\nperception time">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>2.04806913280597</eqn>
+				<eqn>2.05345341966572</eqn>
 				<range min="1" max="3"/>
 				<units>Years</units>
 			</aux>
@@ -7926,13 +7961,13 @@ ELSE 0</eqn>
 				<dimensions>
 					<dim name="Run"/>
 				</dimensions>
-				<eqn>public_expenditure_for_consumption_and_transfers*(1-public_consumption_to_transfers_ratio)+additional_transfers</eqn>
+				<eqn>public_expenditure_for_consumption_and_transfers*(1-climate_adjusted_public_consumption_to_transfers_ratio)+additional_transfers</eqn>
 				<units>b$/year</units>
 			</aux>
 			<aux name="normal\ninvestment share of\npublic expenditure">
 				<doc>${Assumption,Calibration Parameter}
 https://www.oecd-ilibrary.org/sites/e2ee1eb1-en/index.html?itemId=/content/component/e2ee1eb1-en</doc>
-				<eqn>0.0429705648368578</eqn>
+				<eqn>0.0480088518777306</eqn>
 				<range min="0.03" max="0.16"/>
 				<units>dmnl</units>
 			</aux>
@@ -7940,7 +7975,7 @@ https://www.oecd-ilibrary.org/sites/e2ee1eb1-en/index.html?itemId=/content/compo
 				<dimensions>
 					<dim name="Run"/>
 				</dimensions>
-				<eqn>public_expenditure_before_subsidies*climate_adjusted_investment_share_of_public_expenditure</eqn>
+				<eqn>public_expenditure_before_subsidies*normal_investment_share_of_public_expenditure</eqn>
 				<units>b$/year</units>
 			</aux>
 			<aux name="profit tax 1" access="input">
@@ -7974,7 +8009,7 @@ https://www.oecd-ilibrary.org/sites/e2ee1eb1-en/index.html?itemId=/content/compo
 			<aux name="averaging time to adjust tax based on income">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>2.56656888721063</eqn>
+				<eqn>2.56772931727715</eqn>
 				<range min="1" max="3"/>
 				<units>year</units>
 			</aux>
@@ -8031,7 +8066,7 @@ ELSE
 				<units>1/year</units>
 			</aux>
 			<aux name="initial safe interest">
-				<eqn>0.0307759850399812</eqn>
+				<eqn>0.0307842752351262</eqn>
 				<range min="0" max="0.2"/>
 				<units>1/year</units>
 			</aux>
@@ -8564,7 +8599,7 @@ government_interest_payments</eqn>
 			<aux name="maximum effect of debt to GDP\nratio on government spending">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>1.29529237433603</eqn>
+				<eqn>1.30291133464681</eqn>
 				<range min="1.2" max="1.5"/>
 				<units>dmnl</units>
 			</aux>
@@ -8655,7 +8690,7 @@ ELSE
 				<units>1/year</units>
 			</aux>
 			<aux name="average time government refinances debt">
-				<eqn>30</eqn>
+				<eqn>7</eqn>
 				<units>years</units>
 			</aux>
 			<aux name="Surface Temperature Anomaly" access="input">
@@ -8665,14 +8700,14 @@ ELSE
 				<eqn>{Enter equation for use when not hooked up to other models}</eqn>
 				<units>deg C</units>
 			</aux>
-			<aux name="effect of STA\non public investment">
+			<aux name="effect of STA\non public consumption">
 				<dimensions>
 					<dim name="Run"/>
 				</dimensions>
 				<eqn>IF (switch_government_damage=0) AND TIME &gt; today THEN
 PREVIOUS(SELF, 0)
 ELSE
-1+sensitivity_of_effect_of_sta_on_government_investment*(Surface_Temperature_Anomaly)</eqn>
+1+sensitivity_of_STA_on_public_consumption*(Surface_Temperature_Anomaly)</eqn>
 				<units>dmnl</units>
 			</aux>
 			<aux name="switch government damage" access="input">
@@ -8683,20 +8718,60 @@ ELSE
 				<eqn>2025</eqn>
 				<units>year</units>
 			</aux>
-			<aux name="sensitivity of effect\nof sta on government investment">
-				<eqn>0.501330154510088</eqn>
-				<range min="0.1" max="1.1"/>
+			<aux name="sensitivity of STA\non public consumption">
+				<eqn>0.0508862992454978</eqn>
+				<range min="0" max="0.2"/>
 				<units>1/deg C</units>
 			</aux>
-			<aux name="climate adjusted\ninvestment share of\npublic expenditure">
+			<aux name="climate adjusted public\nconsumption to transfers\nratio">
 				<doc>${Assumption,Calibration Parameter}
 https://www.oecd-ilibrary.org/sites/e2ee1eb1-en/index.html?itemId=/content/component/e2ee1eb1-en</doc>
 				<dimensions>
 					<dim name="Run"/>
 				</dimensions>
-				<eqn>normal_investment_share_of_public_expenditure*effect_of_STA_on_public_investment</eqn>
+				<eqn>MIN(1, normal_public_consumption_to_transfers_ratio*effect_of_STA_on_public_consumption)</eqn>
 				<range min="0.04" max="0.16"/>
 				<units>dmnl</units>
+			</aux>
+			<aux name="Population" access="input">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>{Enter equation for use when not hooked up to other models}</eqn>
+				<units>Mp</units>
+			</aux>
+			<aux name="transfer payments per recipient">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>government_transfers/transfer_payment_recipients/&quot;inflation_adjustment_b$_per_bc$_1&quot;*&quot;UNIT_c$_per_Bc$&quot;/UNIT_p_per_mp</eqn>
+				<units>c$/person/year</units>
+			</aux>
+			<aux name="inflation adjustment b$ per bc$ 1" access="input">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>{Enter equation for use when not hooked up to other models}</eqn>
+				<units>b$/bc$</units>
+			</aux>
+			<stock name="Employed" access="input">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>{Enter equation for use when not hooked up to other models}</eqn>
+				<non_negative/>
+				<units>Mp</units>
+			</stock>
+			<aux name="transfer payment recipients">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>(Population - Employed)</eqn>
+				<units>Mp</units>
+			</aux>
+			<aux name="UNIT p per mp">
+				<eqn>1000000</eqn>
+				<units>p/Mp</units>
 			</aux>
 		</variables>
 		<views>
@@ -8747,7 +8822,7 @@ https://www.oecd-ilibrary.org/sites/e2ee1eb1-en/index.html?itemId=/content/compo
 				<isee:iframe color="black" background="white" text_align="left" vertical_text_align="top" font_size="12pt" border_width="thin" border_style="solid"/>
 				<isee:financial_table color="black" background="#E0E0E0" text_align="right" font_size="12pt" hide_border="false" auto_fit="true" first_column_width="250" other_column_width="100" header_font_style="normal" header_font_weight="bold" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="14pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 			</style>
-			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="3" isee:page_rows="4" isee:scroll_y="1" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
+			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="3" isee:page_rows="4" isee:scroll_y="300" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
 				<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
 					<stock color="blue" background="white" font_color="blue" font_size="11pt" label_side="top">
 						<shape type="rectangle" width="45" height="35"/>
@@ -8810,14 +8885,10 @@ https://www.oecd-ilibrary.org/sites/e2ee1eb1-en/index.html?itemId=/content/compo
 					<from>government_interest_payments</from>
 					<to>public_expenditure_for_consumption_and_transfers</to>
 				</connector>
-				<aux label_side="left" x="284.14" y="442.2" name="public\nconsumption to transfers\nratio"/>
+				<aux label_side="top" x="257.14" y="165.667" name="normal public\nconsumption to transfers\nratio"/>
 				<aux label_side="right" x="926.429" y="245.167" name="initial government debt"/>
 				<aux label_side="left" x="765.13" y="1167.76" name="safe\ninterest"/>
 				<aux label_side="left" label_angle="135" x="284.14" y="370.2" name="government\nconsumption"/>
-				<connector uid="12" angle="90">
-					<from>public_consumption_to_transfers_ratio</from>
-					<to>government_consumption</to>
-				</connector>
 				<connector uid="13" angle="127.806">
 					<from>public_expenditure_for_consumption_and_transfers</from>
 					<to>government_consumption</to>
@@ -8843,16 +8914,12 @@ https://www.oecd-ilibrary.org/sites/e2ee1eb1-en/index.html?itemId=/content/compo
 					<to>perceived_GDP</to>
 				</connector>
 				<aux label_side="left" label_angle="225" x="284.14" y="519.42" name="government\ntransfers"/>
-				<connector uid="18" angle="270">
-					<from>public_consumption_to_transfers_ratio</from>
-					<to>government_transfers</to>
-				</connector>
 				<connector uid="19" angle="234.118">
 					<from>public_expenditure_for_consumption_and_transfers</from>
 					<to>government_transfers</to>
 				</connector>
 				<aux label_side="left" x="316" y="77.3583" name="normal\ninvestment share of\npublic expenditure"/>
-				<aux label_side="left" x="339" y="278.025" name="public\ninvestment"/>
+				<aux label_side="left" label_angle="225" x="339" y="278.025" name="public\ninvestment"/>
 				<connector uid="22" angle="270.349">
 					<from>public_investment</from>
 					<to>public_expenditure_for_consumption_and_transfers</to>
@@ -9528,39 +9595,83 @@ https://www.oecd-ilibrary.org/sites/e2ee1eb1-en/index.html?itemId=/content/compo
 					<from>average_time_government_refinances_debt</from>
 					<to>average_government_debt_interest_rate</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" x="84.1429" y="95.3583" name="Surface Temperature Anomaly"/>
-				<aux label_side="bottom" x="209.17" y="125.877" name="effect of STA\non public investment"/>
+				<aux font_style="italic" font_weight="bold" x="57.1429" y="129.358" name="Surface Temperature Anomaly"/>
+				<aux label_side="bottom" x="182.17" y="159.877" name="effect of STA\non public consumption"/>
 				<connector uid="232" angle="346.283">
 					<from>Surface_Temperature_Anomaly</from>
-					<to>effect_of_STA_on_public_investment</to>
+					<to>effect_of_STA_on_public_consumption</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" x="121" y="34" name="switch government damage"/>
-				<aux font_style="italic" font_weight="bold" x="93" y="190.833" name="today"/>
+				<aux font_style="italic" font_weight="bold" x="94" y="68" name="switch government damage"/>
+				<aux font_style="italic" font_weight="bold" x="66" y="224.833" name="today"/>
 				<connector uid="233" angle="313.82">
 					<from>switch_government_damage</from>
-					<to>effect_of_STA_on_public_investment</to>
+					<to>effect_of_STA_on_public_consumption</to>
 				</connector>
 				<connector uid="234" angle="29.2117">
 					<from>today</from>
-					<to>effect_of_STA_on_public_investment</to>
+					<to>effect_of_STA_on_public_consumption</to>
 				</connector>
-				<aux x="146" y="260.025" name="sensitivity of effect\nof sta on government investment"/>
+				<aux x="119" y="294.025" name="sensitivity of STA\non public consumption"/>
 				<connector uid="235" angle="64.7844">
-					<from>sensitivity_of_effect_of_sta_on_government_investment</from>
-					<to>effect_of_STA_on_public_investment</to>
+					<from>sensitivity_of_STA_on_public_consumption</from>
+					<to>effect_of_STA_on_public_consumption</to>
 				</connector>
-				<aux label_side="left" x="313" y="208.833" name="climate adjusted\ninvestment share of\npublic expenditure"/>
+				<aux label_side="right" label_angle="45" x="229" y="261.167" name="climate adjusted public\nconsumption to transfers\nratio"/>
 				<connector uid="236" angle="273.402">
 					<from>normal_investment_share_of_public_expenditure</from>
-					<to>climate_adjusted_investment_share_of_public_expenditure</to>
-				</connector>
-				<connector uid="237" angle="309.38">
-					<from>effect_of_STA_on_public_investment</from>
-					<to>climate_adjusted_investment_share_of_public_expenditure</to>
-				</connector>
-				<connector uid="238" angle="290.288">
-					<from>climate_adjusted_investment_share_of_public_expenditure</from>
 					<to>public_investment</to>
+				</connector>
+				<connector uid="237" angle="282.816">
+					<from>effect_of_STA_on_public_consumption</from>
+					<to>climate_adjusted_public_consumption_to_transfers_ratio</to>
+				</connector>
+				<aux font_style="italic" font_weight="bold" x="75" y="442.2" name="Population"/>
+				<aux x="182" y="641" name="transfer payments per recipient"/>
+				<connector uid="240" angle="229.966">
+					<from>government_transfers</from>
+					<to>transfer_payments_per_recipient</to>
+				</connector>
+				<aux font_style="italic" font_weight="bold" x="168" y="764" name="inflation adjustment b$ per bc$ 1"/>
+				<connector uid="242" angle="83.5065">
+					<from>&quot;inflation_adjustment_b$_per_bc$_1&quot;</from>
+					<to>transfer_payments_per_recipient</to>
+				</connector>
+				<stock font_style="italic" font_weight="bold" x="70" y="524" name="Employed"/>
+				<aux x="164" y="537.42" name="transfer payment recipients"/>
+				<connector uid="244" angle="338.066">
+					<from>Population</from>
+					<to>transfer_payment_recipients</to>
+				</connector>
+				<connector uid="245" angle="16.875">
+					<from>Employed</from>
+					<to>transfer_payment_recipients</to>
+				</connector>
+				<connector uid="246" angle="279.858">
+					<from>transfer_payment_recipients</from>
+					<to>transfer_payments_per_recipient</to>
+				</connector>
+				<connector uid="248" angle="19.9831">
+					<from>
+						<alias uid="249"/>
+					</from>
+					<to>transfer_payments_per_recipient</to>
+				</connector>
+				<connector uid="250" angle="256.662">
+					<from>normal_public_consumption_to_transfers_ratio</from>
+					<to>climate_adjusted_public_consumption_to_transfers_ratio</to>
+				</connector>
+				<connector uid="251" angle="267.783">
+					<from>climate_adjusted_public_consumption_to_transfers_ratio</from>
+					<to>government_consumption</to>
+				</connector>
+				<connector uid="252" angle="264.933">
+					<from>climate_adjusted_public_consumption_to_transfers_ratio</from>
+					<to>government_transfers</to>
+				</connector>
+				<aux x="96" y="858" name="UNIT p per mp"/>
+				<connector uid="253" angle="53.9726">
+					<from>UNIT_p_per_mp</from>
+					<to>transfer_payments_per_recipient</to>
 				</connector>
 				<alias font_style="italic" label_side="right" label_angle="315" uid="73" x="532.797" y="1275.5" width="18" height="18">
 					<of>baseline_interest</of>
@@ -9577,6 +9688,9 @@ https://www.oecd-ilibrary.org/sites/e2ee1eb1-en/index.html?itemId=/content/compo
 				</alias>
 				<alias font_style="italic" font_weight="bold" uid="226" x="562.857" y="694.429" width="18" height="18">
 					<of>start_year</of>
+				</alias>
+				<alias font_style="italic" uid="249" x="76" y="606" width="18" height="18">
+					<of>&quot;UNIT_c$_per_Bc$&quot;</of>
 				</alias>
 			</view>
 		</views>
@@ -9795,17 +9909,17 @@ agriculture_share_of_GDP_starting_point_determinant*EXP(agriculture_share_of_GDP
 				<units>dmnl</units>
 			</aux>
 			<aux name="Agriculture share\nof GDP\nintercept">
-				<eqn>3.27564892308116</eqn>
+				<eqn>3.28171930841537</eqn>
 				<range min="0" max="100"/>
 				<units>dmnl</units>
 			</aux>
 			<aux name="agriculture share\nof GDP slope">
-				<eqn>-2.35890293591449</eqn>
+				<eqn>-2.35624730545799</eqn>
 				<range min="-10" max="1"/>
 				<units>Million*Person*Years/b$</units>
 			</aux>
 			<aux name="agriculture share\nof GDP starting point determinant">
-				<eqn>19.9197721339394</eqn>
+				<eqn>19.9170211531501</eqn>
 				<range min="0" max="20"/>
 				<units>dmnl</units>
 			</aux>
@@ -9893,7 +10007,7 @@ agriculture_share_of_GDP_starting_point_determinant*EXP(agriculture_share_of_GDP
 				<units>1/year</units>
 			</aux>
 			<aux name="deflation\nadjustment time">
-				<eqn>8.73731173254651</eqn>
+				<eqn>8.88984577620975</eqn>
 				<range min="2" max="10"/>
 				<units>years</units>
 			</aux>
@@ -9932,7 +10046,7 @@ agriculture_share_of_GDP_starting_point_determinant*EXP(agriculture_share_of_GDP
 			<aux name="weight of marginal energy\ncost inflation">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>0.0191740703232162</eqn>
+				<eqn>0.0202634165927761</eqn>
 				<range min="0.01" max="2"/>
 				<units>dmnl</units>
 			</aux>
@@ -9960,7 +10074,7 @@ agriculture_share_of_GDP_starting_point_determinant*EXP(agriculture_share_of_GDP
 			<aux name="weight of cropland inflation contribution">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>0.10578219798937</eqn>
+				<eqn>0.104937160666809</eqn>
 				<range min="0.001" max="2"/>
 				<units>dmnl</units>
 			</aux>
@@ -9992,7 +10106,7 @@ agriculture_share_of_GDP_starting_point_determinant*EXP(agriculture_share_of_GDP
 			<aux name="weight of fertilizer used per unit of crop production">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>0.00517984464743103</eqn>
+				<eqn>0.00631626273772212</eqn>
 				<range min="0.001" max="2"/>
 				<units>dmnl</units>
 			</aux>
@@ -10020,7 +10134,7 @@ agriculture_share_of_GDP_starting_point_determinant*EXP(agriculture_share_of_GDP
 			<aux name="weight of grazing land inflation contribution">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>0.0581251329560812</eqn>
+				<eqn>0.0578328707948079</eqn>
 				<range min="0.001" max="2"/>
 				<units>dmnl</units>
 			</aux>
@@ -10052,17 +10166,17 @@ agriculture_share_of_GDP_starting_point_determinant*EXP(agriculture_share_of_GDP
 			<aux name="weight of irrigation water used per unit of crop production inflation contribution">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>0.0490963843684165</eqn>
+				<eqn>0.0474197011985596</eqn>
 				<range min="0.001" max="2"/>
 				<units>dmnl</units>
 			</aux>
 			<aux name="initial inflation index">
-				<eqn>0.418</eqn>
+				<eqn>0.42592993981869</eqn>
 				<range min="0.35" max="0.55"/>
 				<units>dmnl</units>
 			</aux>
 			<aux name="initial inflation rate">
-				<eqn>0.0299278300352081</eqn>
+				<eqn>0.0298988791709621</eqn>
 				<range min="0" max="0.1"/>
 				<units>1/year</units>
 			</aux>
@@ -10123,6 +10237,17 @@ agriculture_share_of_GDP_starting_point_determinant*EXP(agriculture_share_of_GDP
 				<eqn>{Enter equation for use when not hooked up to other models}</eqn>
 				<units>b$/year</units>
 			</aux>
+			<aux name="Inflation Rate as Percent">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>Inflation_Rate*UNIT_Percent</eqn>
+				<units>%/Years</units>
+			</aux>
+			<aux name="UNIT Percent" access="output" isee:autocreated="true">
+				<eqn>100</eqn>
+				<units>%</units>
+			</aux>
 		</variables>
 		<views>
 			<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
@@ -10172,7 +10297,7 @@ agriculture_share_of_GDP_starting_point_determinant*EXP(agriculture_share_of_GDP
 				<isee:iframe color="black" background="white" text_align="left" vertical_text_align="top" font_size="12pt" border_width="thin" border_style="solid"/>
 				<isee:financial_table color="black" background="#E0E0E0" text_align="right" font_size="12pt" hide_border="false" auto_fit="true" first_column_width="250" other_column_width="100" header_font_style="normal" header_font_weight="bold" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="14pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 			</style>
-			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="3" isee:page_rows="3" isee:scroll_x="342" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
+			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="3" isee:page_rows="3" isee:scroll_x="342" isee:scroll_y="468" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
 				<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
 					<stock color="blue" background="white" font_color="blue" font_size="11pt" label_side="top">
 						<shape type="rectangle" width="45" height="35"/>
@@ -10631,6 +10756,16 @@ agriculture_share_of_GDP_starting_point_determinant*EXP(agriculture_share_of_GDP
 					<from>bailouts</from>
 					<to>net_government_expenses</to>
 				</connector>
+				<aux x="760" y="639.659" name="Inflation Rate as Percent"/>
+				<connector uid="101" angle="183.426">
+					<from>Inflation_Rate</from>
+					<to>Inflation_Rate_as_Percent</to>
+				</connector>
+				<aux x="702" y="705.416" name="UNIT Percent"/>
+				<connector uid="102" angle="49.7329">
+					<from>UNIT_Percent</from>
+					<to>Inflation_Rate_as_Percent</to>
+				</connector>
 				<alias color="blue" background="white" font_style="italic" uid="79" x="751" y="993" width="18" height="18">
 					<shape type="circle" radius="18"/>
 					<of>time_to_measure_growth_rate</of>
@@ -10656,7 +10791,7 @@ agriculture_share_of_GDP_starting_point_determinant*EXP(agriculture_share_of_GDP
 			<aux name="normal time to decrease innovation orientation">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>10.0357410824043</eqn>
+				<eqn>10.034351327554</eqn>
 				<range min="5" max="20"/>
 				<units>years</units>
 			</aux>
@@ -10728,7 +10863,7 @@ ELSE MAX(0, Firms_Innovation_Orientation//time_to_decrease_innovation_orientatio
 			<aux name="sensitivity of\nfirms innovation orientation\nto cash deceleration">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>1.01030673741853</eqn>
+				<eqn>1.01264855647784</eqn>
 				<range min="0" max="20"/>
 				<units>dmnl</units>
 			</aux>
@@ -10765,7 +10900,7 @@ ELSE MAX(0, Firms_Innovation_Orientation//time_to_decrease_innovation_orientatio
 			<aux name="sensitivity of innovation\ndecrease to cash growth">
 				<doc>${Calibration Parameter}
 </doc>
-				<eqn>9.99468058962003</eqn>
+				<eqn>9.99502677438678</eqn>
 				<range min="0" max="20"/>
 				<units>dmnl</units>
 			</aux>

--- a/FRIDA_Modules/Economy.itmx
+++ b/FRIDA_Modules/Economy.itmx
@@ -286,14 +286,24 @@
 				<connect2 to='Finance."Real_GDP_in_2021c$"' from='GDP."Real_GDP_in_2021c$"'/>
 				<connect to='Sea_level_rise_adaptation."Real_GDP_in_2021c$"' from='GDP."Real_GDP_in_2021c$"'/>
 				<connect2 to='Sea_level_rise_adaptation."Real_GDP_in_2021c$"' from='GDP."Real_GDP_in_2021c$"'/>
-				<connect to="GDP.government_spending" from="Government.government_consumption"/>
-				<connect2 to="GDP.government_spending" from="Government.government_consumption"/>
+				<connect to="GDP.Government_Spending_1" from="Government.government_consumption"/>
+				<connect2 to="GDP.Government_Spending_1" from="Government.government_consumption"/>
+				<connect to="GDP.government_transfers_1" from="Government.government_transfers"/>
+				<connect2 to="GDP.government_transfers_1" from="Government.government_transfers"/>
 				<connect to='GDP."inflation_adjustment_b$_per_bc$"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
 				<connect2 to='GDP."inflation_adjustment_b$_per_bc$"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
 				<connect to="GDP.Investment_1" from="Finance.total_investment"/>
 				<connect2 to="GDP.Investment_1" from="Finance.total_investment"/>
+				<connect to="GDP.owner_consumption" from="Circular_Flow.owner_consumption"/>
+				<connect2 to="GDP.owner_consumption" from="Circular_Flow.owner_consumption"/>
 				<connect to="GDP.private_consumption_1" from="Circular_Flow.private_consumption"/>
 				<connect2 to="GDP.private_consumption_1" from="Circular_Flow.private_consumption"/>
+				<connect to="GDP.private_investment" from="Circular_Flow.private_investment"/>
+				<connect2 to="GDP.private_investment" from="Circular_Flow.private_investment"/>
+				<connect to="GDP.public_investment" from="Government.public_investment"/>
+				<connect2 to="GDP.public_investment" from="Government.public_investment"/>
+				<connect to="GDP.worker_consumption" from="Circular_Flow.worker_consumption"/>
+				<connect2 to="GDP.worker_consumption" from="Circular_Flow.worker_consumption"/>
 			</module>
 			<module name="Government" isee:label="">
 				<format scale_by="auto"/>
@@ -325,14 +335,16 @@
 				<connect2 to="Circular_Flow.government_consumption" from="Government.government_consumption"/>
 				<connect to="Economy.government_consumption" from="Government.government_consumption"/>
 				<connect2 to="government_consumption" from="Government.government_consumption"/>
-				<connect to="GDP.government_spending" from="Government.government_consumption"/>
-				<connect2 to="GDP.government_spending" from="Government.government_consumption"/>
+				<connect to="GDP.Government_Spending_1" from="Government.government_consumption"/>
+				<connect2 to="GDP.Government_Spending_1" from="Government.government_consumption"/>
 				<connect to="Coastal_Assets.Government_Debt" from="Government.Government_Debt"/>
 				<connect2 to="Coastal_Assets.Government_Debt" from="Government.Government_Debt"/>
 				<connect to="Finance.Government_Debt" from="Government.Government_Debt"/>
 				<connect2 to="Finance.Government_Debt" from="Government.Government_Debt"/>
 				<connect to="Circular_Flow.government_transfers_1" from="Government.government_transfers"/>
 				<connect2 to="Circular_Flow.government_transfers_1" from="Government.government_transfers"/>
+				<connect to="GDP.government_transfers_1" from="Government.government_transfers"/>
+				<connect2 to="GDP.government_transfers_1" from="Government.government_transfers"/>
 				<connect to="Finance.initial_government_debt" from="Government.initial_government_debt"/>
 				<connect2 to="Finance.initial_government_debt" from="Government.initial_government_debt"/>
 				<connect to="Inflation.public_expenditure" from="Government.public_expenditure"/>
@@ -341,6 +353,8 @@
 				<connect2 to="Circular_Flow.public_investment_1" from="Government.public_investment"/>
 				<connect to="Finance.public_investment" from="Government.public_investment"/>
 				<connect2 to="Finance.public_investment" from="Government.public_investment"/>
+				<connect to="GDP.public_investment" from="Government.public_investment"/>
+				<connect2 to="GDP.public_investment" from="Government.public_investment"/>
 				<connect to="Circular_Flow.safe_interest" from="Government.safe_interest"/>
 				<connect2 to="Circular_Flow.safe_interest" from="Government.safe_interest"/>
 				<connect to="Circular_Flow.safe_interest_2" from="Government.safe_interest"/>
@@ -486,12 +500,16 @@
 				<connect2 to="Inflation.non_bank_profits" from="Circular_Flow.non_bank_profits"/>
 				<connect to="Finance.owner_savings_1" from="Circular_Flow.owner_savings"/>
 				<connect2 to="Finance.owner_savings_1" from="Circular_Flow.owner_savings"/>
+				<connect to="GDP.owner_consumption" from="Circular_Flow.owner_consumption"/>
+				<connect2 to="GDP.owner_consumption" from="Circular_Flow.owner_consumption"/>
 				<connect to="Economy.private_consumption_1" from="Circular_Flow.private_consumption"/>
 				<connect2 to="private_consumption_1" from="Circular_Flow.private_consumption"/>
 				<connect to="GDP.private_consumption_1" from="Circular_Flow.private_consumption"/>
 				<connect2 to="GDP.private_consumption_1" from="Circular_Flow.private_consumption"/>
 				<connect to="Finance.private_investment_1" from="Circular_Flow.private_investment"/>
 				<connect2 to="Finance.private_investment_1" from="Circular_Flow.private_investment"/>
+				<connect to="GDP.private_investment" from="Circular_Flow.private_investment"/>
+				<connect2 to="GDP.private_investment" from="Circular_Flow.private_investment"/>
 				<connect to="Government.profit_tax_1" from="Circular_Flow.profit_tax"/>
 				<connect2 to="Government.profit_tax_1" from="Circular_Flow.profit_tax"/>
 				<connect to='Animal_Products_Demand."real_private_consumption_2021$"' from='Circular_Flow."real_private_consumption_2021c$"'/>
@@ -508,6 +526,8 @@
 				<connect2 to="Government.wealth_tax" from="Circular_Flow.wealth_tax"/>
 				<connect to="Finance.Worker_Savings_1" from="Circular_Flow.Worker_Savings"/>
 				<connect2 to="Finance.Worker_Savings_1" from="Circular_Flow.Worker_Savings"/>
+				<connect to="GDP.worker_consumption" from="Circular_Flow.worker_consumption"/>
+				<connect2 to="GDP.worker_consumption" from="Circular_Flow.worker_consumption"/>
 				<connect to="Circular_Flow.annual_aggregate_wages" from="Employment.annual_aggregate_wages"/>
 				<connect2 to="Circular_Flow.annual_aggregate_wages" from="Employment.annual_aggregate_wages"/>
 				<connect to="Circular_Flow.Bank_Investment" from="Finance.Bank_Investment"/>
@@ -524,6 +544,8 @@
 				<connect2 to="Circular_Flow.government_transfers_1" from="Government.government_transfers"/>
 				<connect to='Circular_Flow."inflation_adjustment_b$_per_bc$"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
 				<connect2 to='Circular_Flow."inflation_adjustment_b$_per_bc$"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
+				<connect to='Circular_Flow."inflation_adjustment_b$_per_bc$_1"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
+				<connect2 to='Circular_Flow."inflation_adjustment_b$_per_bc$_1"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
 				<connect to="Circular_Flow.Inflation_Rate" from="Inflation.Inflation_Rate"/>
 				<connect2 to="Circular_Flow.Inflation_Rate" from="Inflation.Inflation_Rate"/>
 				<connect to="Circular_Flow.profit_tax_rate_policy" from="Government_Regulations.profit_tax_rate_policy"/>
@@ -763,6 +785,8 @@
 				<connect2 to='Finance."inflation_adjustment_$_per_c$"' from='Inflation."inflation_adjustment_$_per_c$"'/>
 				<connect to='Circular_Flow."inflation_adjustment_b$_per_bc$"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
 				<connect2 to='Circular_Flow."inflation_adjustment_b$_per_bc$"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
+				<connect to='Circular_Flow."inflation_adjustment_b$_per_bc$_1"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
+				<connect2 to='Circular_Flow."inflation_adjustment_b$_per_bc$_1"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
 				<connect to='Coastal_Assets."inflation_adjustment_b$_per_bc$"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
 				<connect2 to='Coastal_Assets."inflation_adjustment_b$_per_bc$"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
 				<connect to='GDP."inflation_adjustment_b$_per_bc$"' from='Inflation."inflation_adjustment_b$_per_bc$"'/>
@@ -952,7 +976,7 @@
 				<isee:iframe color="black" background="white" text_align="left" vertical_text_align="top" font_size="12pt" border_width="thin" border_style="solid"/>
 				<isee:financial_table color="black" background="#E0E0E0" text_align="right" font_size="12pt" hide_border="false" auto_fit="true" first_column_width="250" other_column_width="100" header_font_style="normal" header_font_weight="bold" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="14pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 			</style>
-			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="2" isee:page_rows="2" isee:scroll_x="315.714" isee:scroll_y="19.2857" zoom="140" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
+			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="2" isee:page_rows="2" isee:scroll_x="240.714" isee:scroll_y="62.1429" zoom="140" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
 				<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
 					<stock color="blue" background="white" font_color="blue" font_size="12.51pt" label_side="top">
 						<shape type="rectangle" width="45" height="35"/>
@@ -1229,7 +1253,7 @@
 				<outflow>firms_taxes</outflow>
 				<units>b$</units>
 			</stock>
-			<flow name="owner consumption">
+			<flow name="owner consumption" access="output" isee:autocreated="true">
 				<dimensions>
 					<dim name="Run"/>
 				</dimensions>
@@ -1338,7 +1362,7 @@ SMTH1(net_owner_income*desired_savings_as_multiple_of_profits, time_to_consider_
 				<non_negative/>
 				<units>b$/year</units>
 			</flow>
-			<flow name="worker consumption">
+			<flow name="worker consumption" access="output" isee:autocreated="true">
 				<dimensions>
 					<dim name="Run"/>
 				</dimensions>
@@ -1449,7 +1473,7 @@ SMTH1((net_worker_income*desired_savings_as_multiple_of_wages), time_to_consider
 				<range min="20000" max="30000"/>
 				<units>b$</units>
 			</aux>
-			<flow name="government spending">
+			<flow name="government spending" access="output" isee:autocreated="true">
 				<dimensions>
 					<dim name="Run"/>
 				</dimensions>
@@ -1501,9 +1525,7 @@ SMTH1((net_worker_income*desired_savings_as_multiple_of_wages), time_to_consider
 				<dimensions>
 					<dim name="Run"/>
 				</dimensions>
-				<eqn>wages
-+transfers
-+worker_savings_interest
+				<eqn>gross_worker_income
 -wage_tax
 {wages
 +transfers
@@ -1524,10 +1546,7 @@ SMTH1((net_worker_income*desired_savings_as_multiple_of_wages), time_to_consider
 				<dimensions>
 					<dim name="Run"/>
 				</dimensions>
-				<eqn>non_bank_profits
-+rent
-+owner_savings_interest
-+bank_profits
+				<eqn>gross_owner_income
 -rent_tax
 -profit_tax</eqn>
 				<units>b$/year</units>
@@ -1858,6 +1877,198 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 				<eqn>RAMP((wealth_taxation_rate)/time_to_implement_tax_policy, start_year, start_year+ time_to_implement_tax_policy)</eqn>
 				<units>1/year</units>
 			</aux>
+			<aux name="gross worker income">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>wages+worker_savings_interest+transfers</eqn>
+				<units>b$/year</units>
+			</aux>
+			<aux name="gross owner income">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>non_bank_profits
++rent
++owner_savings_interest
++bank_profits</eqn>
+				<units>b$/year</units>
+			</aux>
+			<aux name="gross income">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>gross_owner_income+gross_worker_income</eqn>
+				<units>b$/year</units>
+			</aux>
+			<aux name="share of gross income from non bank profits">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>non_bank_profits/gross_income</eqn>
+				<units>dmnl</units>
+			</aux>
+			<aux name="share of gross income from rent">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>rent/gross_income</eqn>
+				<units>dmnl</units>
+			</aux>
+			<aux name="share of gross income from bank profits">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>bank_profits/gross_income</eqn>
+				<units>dmnl</units>
+			</aux>
+			<aux name="share of gross income from owner savings interest">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>owner_savings_interest/gross_income</eqn>
+				<units>dmnl</units>
+			</aux>
+			<aux name="share of gross income from transfers">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>transfers/gross_income</eqn>
+				<units>dmnl</units>
+			</aux>
+			<aux name="share of gross income from worker savings\ninterest">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>worker_savings_interest/gross_income</eqn>
+				<units>dmnl</units>
+			</aux>
+			<aux name="share of gross income from wages">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>wages/gross_income</eqn>
+				<units>1</units>
+			</aux>
+			<aux name="inflation adjustment b$ per bc$ 1" access="input">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>{Enter equation for use when not hooked up to other models}</eqn>
+				<units>b$/bc$</units>
+			</aux>
+			<aux name="non bank profits in 2021c$">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>non_bank_profits/&quot;inflation_adjustment_b$_per_bc$_1&quot;</eqn>
+				<units>bc$/year</units>
+			</aux>
+			<aux name="rent in in 2021c$">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>rent/&quot;inflation_adjustment_b$_per_bc$_1&quot;</eqn>
+				<units>bc$/year</units>
+			</aux>
+			<aux name="bank profits in 2021c$">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>bank_profits/&quot;inflation_adjustment_b$_per_bc$_1&quot;</eqn>
+				<units>bc$/year</units>
+			</aux>
+			<aux name="owner savings interest in 2021c$">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>owner_savings_interest/&quot;inflation_adjustment_b$_per_bc$_1&quot;</eqn>
+				<units>bc$/year</units>
+			</aux>
+			<aux name="transfers in 2021c$">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>transfers/&quot;inflation_adjustment_b$_per_bc$_1&quot;</eqn>
+				<units>bc$/year</units>
+			</aux>
+			<aux name="worker savings interest in 2021c$">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>worker_savings_interest/&quot;inflation_adjustment_b$_per_bc$_1&quot;</eqn>
+				<units>bc$/year</units>
+			</aux>
+			<aux name="wages in 2021c$">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>wages/&quot;inflation_adjustment_b$_per_bc$_1&quot;</eqn>
+				<units>bc$/year</units>
+			</aux>
+			<aux name="wage tax in 2021c$">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>wage_tax/&quot;inflation_adjustment_b$_per_bc$_1&quot;</eqn>
+				<units>bc$/year</units>
+			</aux>
+			<aux name="rent tax in 2021c$">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>rent_tax/&quot;inflation_adjustment_b$_per_bc$_1&quot;</eqn>
+				<units>bc$/year</units>
+			</aux>
+			<aux name="profit tax in 2021c$">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>profit_tax/&quot;inflation_adjustment_b$_per_bc$_1&quot;</eqn>
+				<units>bc$/year</units>
+			</aux>
+			<aux name="net worker income in 2021c$">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>net_worker_income/&quot;inflation_adjustment_b$_per_bc$_1&quot;</eqn>
+				<units>bc$/year</units>
+			</aux>
+			<aux name="net owner income in 2021c$">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>net_owner_income/&quot;inflation_adjustment_b$_per_bc$_1&quot;</eqn>
+				<units>bc$/year</units>
+			</aux>
+			<aux name="wages after tax in 2021c$">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>&quot;wages_in_2021c$&quot;-&quot;wage_tax_in_2021c$&quot;</eqn>
+				<units>bc$/year</units>
+			</aux>
+			<aux name="non bank profits\nafter tax in 2021c$">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>&quot;non_bank_profits_in_2021c$&quot;*(1-actual_profit_tax_rate)</eqn>
+				<units>bc$/year</units>
+			</aux>
+			<aux name="bank profits after tax in 2021c$">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>&quot;bank_profits_in_2021c$&quot;*(1-actual_profit_tax_rate)</eqn>
+				<units>bc$/year</units>
+			</aux>
+			<aux name="rent after tax in 2021c$">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>&quot;rent_in_in_2021c$&quot;-&quot;rent_tax_in_2021c$&quot;</eqn>
+				<units>bc$/year</units>
+			</aux>
 		</variables>
 		<views>
 			<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
@@ -1907,7 +2118,7 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 				<isee:iframe color="black" background="white" text_align="left" vertical_text_align="top" font_size="12pt" border_width="thin" border_style="solid"/>
 				<isee:financial_table color="black" background="#E0E0E0" text_align="right" font_size="12pt" hide_border="false" auto_fit="true" first_column_width="250" other_column_width="100" header_font_style="normal" header_font_weight="bold" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="14pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 			</style>
-			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="3" isee:page_rows="3" isee:scroll_x="476" isee:scroll_y="645" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
+			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="3" isee:page_rows="4" isee:scroll_x="515" isee:scroll_y="300" zoom="80" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
 				<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
 					<stock color="blue" background="white" font_color="blue" font_size="11pt" label_side="top">
 						<shape type="rectangle" width="45" height="35"/>
@@ -1946,45 +2157,45 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 					</graph>
 					<table color="black" background="#E0E0E0" text_align="right" font_size="12pt" orientation="vertical" wrap_text="false" isee:auto_fit="true" isee:use_alternate_row_colors="false" isee:unlimited_table_length="false" blank_column_width="80" column_width="160" interval="1" report_balances="beginning" report_flows="instantaneous" header_font_style="normal" header_font_weight="normal" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="12pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 				</style>
-				<stock label_side="right" x="1208.92" y="506.283" width="115" height="77.5" name="Firms\nChecking\nAccounts"/>
-				<flow label_side="right" label_angle="45" x="1014.43" y="720.25" name="owner consumption">
+				<stock label_side="right" x="1175.17" y="982.533" width="115" height="77.5" name="Firms\nChecking\nAccounts"/>
+				<flow label_side="right" label_angle="45" x="980.683" y="1196.5" name="owner consumption">
 					<pts>
-						<pt x="813.666" y="638.67"/>
-						<pt x="813.666" y="720.25"/>
-						<pt x="1215.2" y="720.25"/>
-						<pt x="1215.2" y="583.783"/>
+						<pt x="779.916" y="1114.92"/>
+						<pt x="779.916" y="1196.5"/>
+						<pt x="1181.45" y="1196.5"/>
+						<pt x="1181.45" y="1060.03"/>
 					</pts>
 				</flow>
-				<flow label_side="bottom" x="1013.18" y="398.892" name="non bank profits">
+				<flow label_side="bottom" x="979.433" y="875.142" name="non bank profits">
 					<pts>
-						<pt x="1217.7" y="506.283"/>
-						<pt x="1217.7" y="398.892"/>
-						<pt x="808.666" y="398.892"/>
-						<pt x="808.666" y="455.17"/>
+						<pt x="1183.95" y="982.533"/>
+						<pt x="1183.95" y="875.142"/>
+						<pt x="774.916" y="875.142"/>
+						<pt x="774.916" y="931.42"/>
 					</pts>
 				</flow>
 				<connector uid="1" angle="126.034">
 					<from>Firms_Checking_Accounts</from>
 					<to>non_bank_profits</to>
 				</connector>
-				<stock label_side="bottom" x="757.417" y="455.17" width="102.5" height="183.5" name="owner\nsavings"/>
-				<aux label_side="top" x="683.667" y="193.79" name="desired savings\nas multiple of\nprofits"/>
-				<aux label_side="left" x="553.751" y="400.892" name="owner savings\ngoal shortfall"/>
+				<stock label_side="bottom" x="723.667" y="931.42" width="102.5" height="183.5" name="owner\nsavings"/>
+				<aux label_side="top" x="649.917" y="670.04" name="desired savings\nas multiple of\nprofits"/>
+				<aux label_side="left" x="520.001" y="877.142" name="owner savings\ngoal shortfall"/>
 				<connector uid="2" angle="112.454">
 					<from>owner_savings</from>
 					<to>owner_savings_goal_shortfall</to>
 				</connector>
-				<aux label_side="right" label_angle="315" x="704.084" y="273.25" name="desired owner\nsavings"/>
+				<aux label_side="right" label_angle="315" x="670.334" y="749.5" name="desired owner\nsavings"/>
 				<connector uid="3" angle="203.922">
 					<from>desired_owner_savings</from>
 					<to>owner_savings_goal_shortfall</to>
 				</connector>
-				<aux label_side="left" label_angle="135" x="635.75" y="211.79" name="time to consider desired savings"/>
+				<aux label_side="left" label_angle="135" x="602" y="688.04" name="time to consider desired savings"/>
 				<connector uid="4" angle="318.032">
 					<from>time_to_consider_desired_savings</from>
 					<to>desired_owner_savings</to>
 				</connector>
-				<aux label_side="top" x="419.084" y="741.391" name="time to reach\nsavings goal"/>
+				<aux label_side="top" x="385.334" y="1217.64" name="time to reach\nsavings goal"/>
 				<connector uid="5" angle="49.0508">
 					<from>time_to_reach_savings_goal</from>
 					<to>annual_owner_savings_to_reach_goal</to>
@@ -1993,43 +2204,43 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 					<from>owner_savings_goal_shortfall</from>
 					<to>annual_owner_savings_to_reach_goal</to>
 				</connector>
-				<aux label_side="left" label_angle="225" x="524.751" y="619.617" name="annual\nowner savings\nto reach goal"/>
-				<aux label_side="right" x="995.56" y="952.381" name="minimum\nfraction of income\nto consumption"/>
-				<stock label_side="right" label_angle="315" x="1678" y="455.17" width="102.5" height="183.5" name="Worker\nSavings"/>
-				<flow x="1519.43" y="398.892" name="wages">
+				<aux label_side="left" label_angle="225" x="491.001" y="1095.87" name="annual\nowner savings\nto reach goal"/>
+				<aux label_side="right" x="961.81" y="1428.63" name="minimum\nfraction of income\nto consumption"/>
+				<stock label_side="right" label_angle="315" x="1644.25" y="931.42" width="102.5" height="183.5" name="Worker\nSavings"/>
+				<flow x="1485.68" y="875.142" name="wages">
 					<pts>
-						<pt x="1312.25" y="506.283"/>
-						<pt x="1312.25" y="398.892"/>
-						<pt x="1726.61" y="398.892"/>
-						<pt x="1726.61" y="455.17"/>
+						<pt x="1278.5" y="982.533"/>
+						<pt x="1278.5" y="875.142"/>
+						<pt x="1692.86" y="875.142"/>
+						<pt x="1692.86" y="931.42"/>
 					</pts>
 				</flow>
-				<flow label_side="left" label_angle="135" x="1521.93" y="718" name="worker consumption">
+				<flow label_side="left" label_angle="135" x="1488.18" y="1194.25" name="worker consumption">
 					<pts>
-						<pt x="1730.36" y="638.67"/>
-						<pt x="1730.36" y="718"/>
-						<pt x="1313.5" y="718"/>
-						<pt x="1313.5" y="583.783"/>
+						<pt x="1696.61" y="1114.92"/>
+						<pt x="1696.61" y="1194.25"/>
+						<pt x="1279.75" y="1194.25"/>
+						<pt x="1279.75" y="1060.03"/>
 					</pts>
 				</flow>
-				<aux label_side="right" label_angle="315" x="1998.58" y="652.391" name="annual\nworker savings\nto reach goal"/>
+				<aux label_side="right" label_angle="315" x="1964.83" y="1128.64" name="annual\nworker savings\nto reach goal"/>
 				<connector uid="7" angle="215.188">
 					<from>
 						<alias uid="8"/>
 					</from>
 					<to>annual_worker_savings_to_reach_goal</to>
 				</connector>
-				<aux label_side="right" x="1984.33" y="390.892" name="worker savings\ngoal shortfall"/>
+				<aux label_side="right" x="1950.58" y="867.142" name="worker savings\ngoal shortfall"/>
 				<connector uid="9" angle="290.383">
 					<from>worker_savings_goal_shortfall</from>
 					<to>annual_worker_savings_to_reach_goal</to>
 				</connector>
-				<aux label_side="bottom" x="1828.58" y="271.49" name="desired worker\nsavings"/>
+				<aux label_side="bottom" x="1794.83" y="747.74" name="desired worker\nsavings"/>
 				<connector uid="10" angle="343.157">
 					<from>desired_worker_savings</from>
 					<to>worker_savings_goal_shortfall</to>
 				</connector>
-				<aux label_side="top" x="1789.5" y="211.79" name="desired savings\nas multiple of\nwages"/>
+				<aux label_side="top" x="1755.75" y="688.04" name="desired savings\nas multiple of\nwages"/>
 				<connector uid="11" angle="256.957">
 					<from>
 						<alias uid="12"/>
@@ -2040,88 +2251,88 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 					<from>Worker_Savings</from>
 					<to>worker_savings_goal_shortfall</to>
 				</connector>
-				<flow label_side="top" x="1229.75" y="697.141" name="firms paying\ninterest">
+				<flow label_side="top" x="1196" y="1173.39" name="firms paying\ninterest">
 					<pts>
-						<pt x="1229.75" y="583.783"/>
-						<pt x="1229.75" y="831.5"/>
+						<pt x="1196" y="1060.03"/>
+						<pt x="1196" y="1307.75"/>
 					</pts>
 				</flow>
-				<flow label_side="top" x="1618.88" y="505.75" name="worker savings\ninterest">
+				<flow label_side="top" x="1585.13" y="982" name="worker savings\ninterest">
 					<pts>
-						<pt x="1559.75" y="505.75"/>
-						<pt x="1678" y="505.75"/>
+						<pt x="1526" y="982"/>
+						<pt x="1644.25" y="982"/>
 					</pts>
 				</flow>
-				<flow label_side="top" x="923.583" y="607.75" name="owner savings interest">
+				<flow label_side="top" x="889.833" y="1084" name="owner savings interest">
 					<pts>
-						<pt x="987.25" y="607.75"/>
-						<pt x="859.917" y="607.75"/>
+						<pt x="953.5" y="1084"/>
+						<pt x="826.167" y="1084"/>
 					</pts>
 				</flow>
 				<connector uid="14" angle="305.981">
 					<from>owner_savings</from>
 					<to>owner_savings_interest</to>
 				</connector>
-				<flow label_side="bottom" x="923.583" y="505.25" name="bank profits">
+				<flow label_side="bottom" x="889.833" y="981.5" name="bank profits">
 					<pts>
-						<pt x="987.25" y="505.25"/>
-						<pt x="859.917" y="505.25"/>
+						<pt x="953.5" y="981.5"/>
+						<pt x="826.167" y="981.5"/>
 					</pts>
 				</flow>
-				<flow x="1833.13" y="552.75" name="wage tax">
+				<flow x="1799.38" y="1029" name="wage tax">
 					<pts>
-						<pt x="1780.5" y="552.75"/>
-						<pt x="1909.75" y="552.75"/>
+						<pt x="1746.75" y="1029"/>
+						<pt x="1876" y="1029"/>
 					</pts>
 				</flow>
-				<aux label_side="bottom" x="2013.08" y="778" name="wage tax rate"/>
+				<aux label_side="bottom" x="1979.33" y="1254.25" name="wage tax rate"/>
 				<connector uid="16" angle="219.138">
 					<from>
 						<alias uid="17"/>
 					</from>
 					<to>wage_tax</to>
 				</connector>
-				<connector uid="18" angle="128.749">
+				<connector uid="18" angle="128.75">
 					<from>Worker_Savings</from>
 					<to>worker_savings_interest</to>
 				</connector>
-				<flow label_side="left" label_angle="225" x="696.209" y="484" name="profit tax">
+				<flow label_side="left" label_angle="225" x="662.459" y="960.25" name="profit tax">
 					<pts>
-						<pt x="757.417" y="484"/>
-						<pt x="611" y="484"/>
+						<pt x="723.667" y="960.25"/>
+						<pt x="577.25" y="960.25"/>
 					</pts>
 				</flow>
-				<aux x="752.167" y="682.58" name="initial owner savings"/>
-				<aux label_side="right" x="1347.42" y="603.617" name="initial firms\nchecking accounts"/>
-				<aux x="1799.13" y="715.141" name="initial worker savings"/>
-				<flow label_side="left" label_angle="135" x="1234.63" y="388.267" name="government spending">
+				<aux x="718.417" y="1158.83" name="initial owner savings"/>
+				<aux label_side="right" x="1313.67" y="1079.87" name="initial firms\nchecking accounts"/>
+				<aux x="1765.38" y="1191.39" name="initial worker savings"/>
+				<flow label_side="left" label_angle="135" x="1200.88" y="864.516" name="government spending">
 					<pts>
-						<pt x="1234.63" y="270.25"/>
-						<pt x="1234.63" y="506.283"/>
+						<pt x="1200.88" y="746.5"/>
+						<pt x="1200.88" y="982.533"/>
 					</pts>
 				</flow>
-				<flow label_side="right" label_angle="45" x="1284.75" y="388.267" name="private investment">
+				<flow label_side="right" label_angle="45" x="1251" y="864.516" name="private investment">
 					<pts>
-						<pt x="1284.75" y="270.25"/>
-						<pt x="1284.75" y="506.283"/>
+						<pt x="1251" y="746.5"/>
+						<pt x="1251" y="982.533"/>
 					</pts>
 				</flow>
-				<aux x="436.833" y="131.996" name="private consumption"/>
-				<aux label_side="top" x="1052.31" y="364.54" name="time to pay out profits"/>
+				<aux x="403.083" y="608.246" name="private consumption"/>
+				<aux label_side="top" x="1018.56" y="840.79" name="time to pay out profits"/>
 				<connector uid="20" angle="221.282">
 					<from>time_to_pay_out_profits</from>
 					<to>non_bank_profits</to>
 				</connector>
-				<flow label_side="top" x="1040.42" y="553.158" name="rent">
+				<flow label_side="top" x="1006.67" y="1029.41" name="rent">
 					<pts>
-						<pt x="1208.92" y="553.158"/>
-						<pt x="859.917" y="553.158"/>
+						<pt x="1175.17" y="1029.41"/>
+						<pt x="826.167" y="1029.41"/>
 					</pts>
 				</flow>
-				<flow label_side="left" label_angle="135" x="696.209" y="591.5" name="rent tax">
+				<flow label_side="left" label_angle="135" x="662.459" y="1067.75" name="rent tax">
 					<pts>
-						<pt x="757.417" y="591.5"/>
-						<pt x="611" y="591.5"/>
+						<pt x="723.667" y="1067.75"/>
+						<pt x="577.25" y="1067.75"/>
 					</pts>
 				</flow>
 				<connector uid="22" angle="338.199">
@@ -2130,35 +2341,19 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 					</from>
 					<to>private_consumption</to>
 				</connector>
-				<connector uid="24" angle="293.591">
+				<connector uid="24" angle="293.592">
 					<from>
 						<alias uid="25"/>
 					</from>
 					<to>private_consumption</to>
 				</connector>
-				<aux label_side="right" label_angle="315" x="1615.84" y="299.49" name="net worker income"/>
-				<flow label_side="top" x="1622.63" y="601.5" name="transfers">
+				<aux label_side="right" label_angle="315" x="1582.09" y="775.74" name="net worker income"/>
+				<flow label_side="top" x="1588.88" y="1077.75" name="transfers">
 					<pts>
-						<pt x="1567.25" y="601.5"/>
-						<pt x="1678" y="601.5"/>
+						<pt x="1533.5" y="1077.75"/>
+						<pt x="1644.25" y="1077.75"/>
 					</pts>
 				</flow>
-				<connector uid="26" angle="61.3097">
-					<from>wages</from>
-					<to>net_worker_income</to>
-				</connector>
-				<connector uid="27" angle="343.45">
-					<from>
-						<alias uid="28"/>
-					</from>
-					<to>net_worker_income</to>
-				</connector>
-				<connector uid="29" angle="290.641">
-					<from>
-						<alias uid="30"/>
-					</from>
-					<to>net_worker_income</to>
-				</connector>
 				<connector uid="31" angle="28.373">
 					<from>net_worker_income</from>
 					<to>desired_worker_savings</to>
@@ -2167,30 +2362,12 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 					<from>desired_savings_as_multiple_of_wages</from>
 					<to>desired_worker_savings</to>
 				</connector>
-				<aux label_side="bottom" x="923.667" y="299.49" name="net owner income"/>
-				<connector uid="33" angle="118.036">
+				<aux label_side="bottom" x="855.917" y="709.74" name="net owner income"/>
+				<connector uid="33" angle="112.783">
 					<from>non_bank_profits</from>
-					<to>net_owner_income</to>
+					<to>gross_owner_income</to>
 				</connector>
-				<connector uid="34" angle="280.033">
-					<from>
-						<alias uid="35"/>
-					</from>
-					<to>net_owner_income</to>
-				</connector>
-				<connector uid="36" angle="301.373">
-					<from>
-						<alias uid="37"/>
-					</from>
-					<to>net_owner_income</to>
-				</connector>
-				<connector uid="38" angle="255.205">
-					<from>
-						<alias uid="39"/>
-					</from>
-					<to>net_owner_income</to>
-				</connector>
-				<connector uid="40" angle="149.341">
+				<connector uid="40" angle="168.248">
 					<from>net_owner_income</from>
 					<to>desired_owner_savings</to>
 				</connector>
@@ -2222,45 +2399,45 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 					</from>
 					<to>net_worker_income</to>
 				</connector>
-				<connector uid="50" angle="210.263">
+				<connector uid="50" angle="251.126">
 					<from>
 						<alias uid="51"/>
 					</from>
 					<to>net_owner_income</to>
 				</connector>
-				<connector uid="52" angle="233.062">
+				<connector uid="52" angle="277.114">
 					<from>
 						<alias uid="53"/>
 					</from>
 					<to>net_owner_income</to>
 				</connector>
-				<stock font_style="italic" font_weight="bold" x="1365.83" y="261.481" width="21.6667" height="16.8519" name="Bank\nInvestment"/>
+				<stock font_style="italic" font_weight="bold" x="1332.08" y="737.731" width="21.6667" height="16.8519" name="Bank\nInvestment"/>
 				<connector uid="54" angle="232.168">
 					<from>Bank_Investment</from>
 					<to>private_investment</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" label_side="top" x="1181" y="251.481" name="government\nconsumption"/>
+				<aux font_style="italic" font_weight="bold" label_side="top" x="1147.25" y="727.731" name="government\nconsumption"/>
 				<connector uid="55" angle="291.409">
 					<from>government_consumption</from>
 					<to>government_spending</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" label_side="left" label_angle="135" x="1168.5" y="294" name="public\ninvestment 1"/>
+				<aux font_style="italic" font_weight="bold" label_side="left" label_angle="135" x="1134.75" y="770.25" name="public\ninvestment 1"/>
 				<connector uid="56" angle="305.05">
 					<from>public_investment_1</from>
 					<to>government_spending</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" x="1622.63" y="652.391" name="government\ntransfers 1"/>
+				<aux font_style="italic" font_weight="bold" x="1588.88" y="1128.64" name="government\ntransfers 1"/>
 				<connector uid="57" angle="118.657">
 					<from>government_transfers_1</from>
 					<to>transfers</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" x="938.333" y="655.617" name="safe\ninterest 2"/>
+				<aux font_style="italic" font_weight="bold" x="904.583" y="1131.87" name="safe\ninterest 2"/>
 				<connector uid="58" angle="92.7604">
 					<from>safe_interest_2</from>
 					<to>owner_savings_interest</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" label_side="left" label_angle="225" x="1195" y="818.095" name="safe bank assets"/>
-				<aux font_style="italic" font_weight="bold" label_side="left" label_angle="225" x="1195" y="860.333" name="risky bank assets"/>
+				<aux font_style="italic" font_weight="bold" label_side="left" label_angle="225" x="1161.25" y="1294.35" name="safe bank assets"/>
+				<aux font_style="italic" font_weight="bold" label_side="left" label_angle="225" x="1161.25" y="1336.58" name="risky bank assets"/>
 				<connector uid="59" angle="73.9706">
 					<from>safe_bank_assets</from>
 					<to>firms_paying_interest</to>
@@ -2269,13 +2446,13 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 					<from>risky_bank_assets</from>
 					<to>firms_paying_interest</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" label_side="right" label_angle="315" x="1263.42" y="860.333" name="risky\ninterest 1"/>
+				<aux font_style="italic" font_weight="bold" label_side="right" label_angle="315" x="1229.67" y="1336.58" name="risky\ninterest 1"/>
 				<connector uid="61" angle="101.658">
 					<from>risky_interest_1</from>
 					<to>firms_paying_interest</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" label_side="left" label_angle="225" x="1519.43" y="465" name="safe\ninterest"/>
-				<aux font_style="italic" font_weight="bold" label_side="right" x="1267.75" y="818.095" name="safe\ninterest 3"/>
+				<aux font_style="italic" font_weight="bold" label_side="left" label_angle="225" x="1485.68" y="941.25" name="safe\ninterest"/>
+				<aux font_style="italic" font_weight="bold" label_side="right" x="1234" y="1294.35" name="safe\ninterest 3"/>
 				<connector uid="62" angle="337.717">
 					<from>safe_interest</from>
 					<to>worker_savings_interest</to>
@@ -2284,21 +2461,21 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 					<from>safe_interest_3</from>
 					<to>firms_paying_interest</to>
 				</connector>
-				<aux label_side="left" x="1527.33" y="890.096" name="fraction of income to consumption"/>
-				<aux label_side="right" x="995.56" y="902.738" name="fraction of\nowner income\nto consumption"/>
-				<aux label_side="left" label_angle="225" x="864.43" y="855.857" name="consumption habits adjustment time"/>
-				<aux font_style="italic" font_weight="bold" x="1088" y="589.75" name="rent 3"/>
+				<aux label_side="left" x="1493.58" y="1366.35" name="fraction of income to consumption"/>
+				<aux label_side="right" x="961.81" y="1378.99" name="fraction of\nowner income\nto consumption"/>
+				<aux label_side="left" label_angle="225" x="830.68" y="1332.11" name="consumption habits adjustment time"/>
+				<aux font_style="italic" font_weight="bold" x="1054.25" y="1066" name="rent 3"/>
 				<connector uid="67" angle="142.438">
 					<from>rent_3</from>
 					<to>rent</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" label_side="left" label_angle="135" x="1477" y="346.54" name="annual\naggregate wages"/>
+				<aux font_style="italic" font_weight="bold" label_side="left" label_angle="135" x="1443.25" y="822.79" name="annual\naggregate wages"/>
 				<connector uid="68" angle="309.024">
 					<from>annual_aggregate_wages</from>
 					<to>wages</to>
 				</connector>
-				<aux label_side="left" label_angle="135" x="934.43" y="925.238" name="indicated owner\nconsumption"/>
-				<aux label_side="right" x="934.43" y="825" name="actual owner\nconsumption"/>
+				<aux label_side="left" label_angle="135" x="900.68" y="1401.49" name="indicated owner\nconsumption"/>
+				<aux label_side="right" x="900.68" y="1301.25" name="actual owner\nconsumption"/>
 				<connector uid="69" angle="91.4752">
 					<from>
 						<alias uid="70"/>
@@ -2329,7 +2506,7 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 					<from>actual_owner_consumption</from>
 					<to>owner_consumption</to>
 				</connector>
-				<aux label_side="left" x="825.583" y="1023.83" name="actual percentage of owner income to consumption"/>
+				<aux label_side="left" x="791.833" y="1500.08" name="actual percentage of owner income to consumption"/>
 				<connector uid="77" angle="193.014">
 					<from>
 						<alias uid="70"/>
@@ -2342,8 +2519,8 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 					</from>
 					<to>actual_percentage_of_owner_income_to_consumption</to>
 				</connector>
-				<aux label_side="left" x="1606.93" y="825" name="actual worker\nconsumption"/>
-				<aux label_side="right" label_angle="45" x="1606.93" y="925.238" name="indicated worker\nconsumption"/>
+				<aux label_side="left" x="1573.18" y="1301.25" name="actual worker\nconsumption"/>
+				<aux label_side="right" label_angle="45" x="1573.18" y="1401.49" name="indicated worker\nconsumption"/>
 				<connector uid="80" angle="90">
 					<from>
 						<alias uid="81"/>
@@ -2378,7 +2555,7 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 					<from>actual_worker_consumption</from>
 					<to>worker_consumption</to>
 				</connector>
-				<aux label_side="top" x="1725.63" y="1023.83" name="actual percentage of worker income to consumption"/>
+				<aux label_side="top" x="1691.88" y="1500.08" name="actual percentage of worker income to consumption"/>
 				<connector uid="90" angle="346.707">
 					<from>
 						<alias uid="81"/>
@@ -2391,7 +2568,7 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 					</from>
 					<to>actual_percentage_of_worker_income_to_consumption</to>
 				</connector>
-				<aux label_side="left" label_angle="225" x="840" y="342.5" name="ratio of profits\nto wages"/>
+				<aux label_side="left" label_angle="225" x="806.25" y="818.75" name="ratio of profits\nto wages"/>
 				<connector uid="93" angle="161.964">
 					<from>non_bank_profits</from>
 					<to>ratio_of_profits_to_wages</to>
@@ -2400,27 +2577,27 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 					<from>wages</from>
 					<to>ratio_of_profits_to_wages</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" label_side="left" x="1195" y="778" name="exploratory\nbank assets"/>
+				<aux font_style="italic" font_weight="bold" label_side="left" x="1161.25" y="1254.25" name="exploratory\nbank assets"/>
 				<connector uid="95" angle="66.7438">
 					<from>exploratory_bank_assets</from>
 					<to>firms_paying_interest</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" label_side="right" x="1267.75" y="778" name="exploratory\ninterest"/>
+				<aux font_style="italic" font_weight="bold" label_side="right" x="1234" y="1254.25" name="exploratory\ninterest"/>
 				<connector uid="96" angle="115.171">
 					<from>exploratory_interest</from>
 					<to>firms_paying_interest</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" label_side="right" x="1013.56" y="465" name="bank profit\npayment 1"/>
+				<aux font_style="italic" font_weight="bold" label_side="right" x="979.81" y="941.25" name="bank profit\npayment 1"/>
 				<connector uid="97" angle="204.101">
 					<from>bank_profit_payment_1</from>
 					<to>bank_profits</to>
 				</connector>
-				<aux label_side="left" label_angle="225" x="864.43" y="798.095" name="inflation effect\non consumption"/>
+				<aux label_side="left" label_angle="225" x="830.68" y="1274.35" name="inflation effect\non consumption"/>
 				<connector uid="98" angle="338.975">
 					<from>inflation_effect_on_consumption</from>
 					<to>actual_owner_consumption</to>
 				</connector>
-				<aux label_side="right" x="882.43" y="763" name="one year"/>
+				<aux label_side="right" x="848.68" y="1239.25" name="one year"/>
 				<connector uid="99" angle="242.847">
 					<from>one_year</from>
 					<to>inflation_effect_on_consumption</to>
@@ -2431,18 +2608,18 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 					</from>
 					<to>actual_worker_consumption</to>
 				</connector>
-				<stock font_style="italic" font_weight="bold" x="779.167" y="753.667" width="24" height="18.6667" name="Inflation Rate"/>
-				<connector uid="102" angle="334.404">
+				<stock font_style="italic" font_weight="bold" x="745.417" y="1229.92" width="24" height="18.6667" name="Inflation Rate"/>
+				<connector uid="102" angle="334.405">
 					<from>Inflation_Rate</from>
 					<to>inflation_effect_on_consumption</to>
 				</connector>
-				<aux x="1082" y="1394" name="firms cash net flow"/>
-				<aux label_side="top" x="1208" y="1394" name="firms cash outflow"/>
+				<aux x="1048.25" y="1870.25" name="firms cash net flow"/>
+				<aux label_side="top" x="1174.25" y="1870.25" name="firms cash outflow"/>
 				<connector uid="103" angle="180">
 					<from>firms_cash_outflow</from>
 					<to>firms_cash_net_flow</to>
 				</connector>
-				<aux x="918.31" y="1394" name="Firms cash inflow"/>
+				<aux x="884.56" y="1870.25" name="Firms cash inflow"/>
 				<connector uid="104" angle="0">
 					<from>Firms_cash_inflow</from>
 					<to>firms_cash_net_flow</to>
@@ -2495,28 +2672,28 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 					</from>
 					<to>firms_cash_outflow</to>
 				</connector>
-				<aux x="430" y="240" name="real private consumption 2021c$"/>
+				<aux x="396.25" y="716.25" name="real private consumption 2021c$"/>
 				<connector uid="122" angle="273.757">
 					<from>private_consumption</from>
 					<to>&quot;real_private_consumption_2021c$&quot;</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" x="1346" y="973" name="sum of energy taxes"/>
-				<flow label_side="top" x="1289" y="693.391" name="firms taxes">
+				<aux font_style="italic" font_weight="bold" x="1312.25" y="1449.25" name="sum of energy taxes"/>
+				<flow label_side="top" x="1255.25" y="1169.64" name="firms taxes">
 					<pts>
-						<pt x="1289" y="583.783"/>
-						<pt x="1289" y="824"/>
+						<pt x="1255.25" y="1060.03"/>
+						<pt x="1255.25" y="1300.25"/>
 					</pts>
 				</flow>
 				<connector uid="123" angle="102.529">
 					<from>sum_of_energy_taxes</from>
 					<to>firms_taxes</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" x="1226" y="134" name="sum of subsidies spent"/>
+				<aux font_style="italic" font_weight="bold" x="1192.25" y="610.25" name="sum of subsidies spent"/>
 				<connector uid="124" angle="278.427">
 					<from>sum_of_subsidies_spent</from>
 					<to>government_spending</to>
 				</connector>
-				<aux x="1177" y="1251" name="income inequality"/>
+				<aux x="1143.25" y="1727.25" name="income inequality"/>
 				<connector uid="125" angle="299.358">
 					<from>
 						<alias uid="126"/>
@@ -2529,14 +2706,14 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 					</from>
 					<to>income_inequality</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" x="237" y="226" name="inflation adjustment b$ per bc$"/>
+				<aux font_style="italic" font_weight="bold" x="203.25" y="702.25" name="inflation adjustment b$ per bc$"/>
 				<connector uid="129" angle="1.68468">
 					<from>&quot;inflation_adjustment_b$_per_bc$&quot;</from>
 					<to>&quot;real_private_consumption_2021c$&quot;</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" x="2042.33" y="878.333" name="wage tax policy"/>
-				<aux font_style="italic" font_weight="bold" x="2122" y="764" name="start year"/>
-				<aux x="1902" y="679.141" name="actual wage tax rate"/>
+				<aux font_style="italic" font_weight="bold" x="2008.58" y="1354.58" name="wage tax policy"/>
+				<aux font_style="italic" font_weight="bold" x="2088.25" y="1240.25" name="start year"/>
+				<aux x="1868.25" y="1155.39" name="actual wage tax rate"/>
 				<connector uid="130" angle="125.165">
 					<from>wage_tax_policy</from>
 					<to>actual_wage_tax_rate</to>
@@ -2553,13 +2730,13 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 					<from>actual_wage_tax_rate</from>
 					<to>wage_tax</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" x="1845" y="857" name="switch tax policy"/>
+				<aux font_style="italic" font_weight="bold" x="1811.25" y="1333.25" name="switch tax policy"/>
 				<connector uid="134" angle="72.5528">
 					<from>switch_tax_policy</from>
 					<to>actual_wage_tax_rate</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" x="431" y="463" name="profit tax rate policy"/>
-				<aux x="588" y="529" name="actual profit tax rate"/>
+				<aux font_style="italic" font_weight="bold" x="397.25" y="939.25" name="profit tax rate policy"/>
+				<aux x="554.25" y="1005.25" name="actual profit tax rate"/>
 				<connector uid="135" angle="327.095">
 					<from>profit_tax_rate_policy</from>
 					<to>actual_profit_tax_rate</to>
@@ -2584,13 +2761,13 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 					</from>
 					<to>actual_profit_tax_rate</to>
 				</connector>
-				<aux x="1351" y="1039.83" name="Actual people retreat cost from SLR"/>
-				<aux x="1242.75" y="1048.71" name="Time to pay for SLR retreat costs"/>
+				<aux x="1317.25" y="1516.08" name="Actual people retreat cost from SLR"/>
+				<aux x="1209" y="1524.96" name="Time to pay for SLR retreat costs"/>
 				<connector uid="143" angle="4.68961">
 					<from>Time_to_pay_for_SLR_retreat_costs</from>
 					<to>Actual_people_retreat_cost_from_SLR</to>
 				</connector>
-				<aux x="1351" y="1110" name="Initial actual people retreat cost from SLR"/>
+				<aux x="1317.25" y="1586.25" name="Initial actual people retreat cost from SLR"/>
 				<connector uid="144" angle="90">
 					<from>Initial_actual_people_retreat_cost_from_SLR</from>
 					<to>Actual_people_retreat_cost_from_SLR</to>
@@ -2599,13 +2776,13 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 					<from>Actual_people_retreat_cost_from_SLR</from>
 					<to>owner_consumption</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" x="1459" y="1110" name="Total nominal people\nretreat costs"/>
+				<aux font_style="italic" font_weight="bold" x="1425.25" y="1586.25" name="Total nominal people\nretreat costs"/>
 				<connector uid="146" angle="111.801">
 					<from>Total_nominal_people_retreat_costs</from>
 					<to>Actual_people_retreat_cost_from_SLR</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" x="224" y="601.617" name="time to implement\ntax policy"/>
-				<aux label_side="left" x="333.084" y="562.75" name="profit tax rate"/>
+				<aux font_style="italic" font_weight="bold" x="190.25" y="1077.87" name="time to implement\ntax policy"/>
+				<aux label_side="left" x="299.334" y="1039" name="profit tax rate"/>
 				<connector uid="136" angle="7.5419">
 					<from>profit_tax_rate</from>
 					<to>actual_profit_tax_rate</to>
@@ -2620,11 +2797,11 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 					</from>
 					<to>actual_wage_tax_rate</to>
 				</connector>
-				<aux font_style="italic" font_weight="bold" x="562" y="798.095" name="wealth taxation rate"/>
-				<flow x="692.709" y="541" name="wealth tax">
+				<aux font_style="italic" font_weight="bold" x="528.25" y="1274.35" name="wealth taxation rate"/>
+				<flow x="658.959" y="1017.25" name="wealth tax">
 					<pts>
-						<pt x="757.417" y="541"/>
-						<pt x="604" y="541"/>
+						<pt x="723.667" y="1017.25"/>
+						<pt x="570.25" y="1017.25"/>
 					</pts>
 				</flow>
 				<connector uid="150" angle="153.383">
@@ -2643,7 +2820,7 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 					</from>
 					<to>wealth_tax</to>
 				</connector>
-				<aux x="580" y="580.75" name="actual wealth tax rate"/>
+				<aux x="546.25" y="1057" name="actual wealth tax rate"/>
 				<connector uid="155" angle="79.9409">
 					<from>wealth_taxation_rate</from>
 					<to>actual_wealth_tax_rate</to>
@@ -2662,116 +2839,488 @@ net_worker_income*fraction_of_income_to_consumption-annual_worker_savings_to_rea
 					<from>actual_wealth_tax_rate</from>
 					<to>wealth_tax</to>
 				</connector>
-				<alias label_side="top" uid="8" x="2058.75" y="594.617" width="18" height="18">
+				<aux x="1539.25" y="809.75" name="gross worker income"/>
+				<connector uid="163" angle="50.6752">
+					<from>wages</from>
+					<to>gross_worker_income</to>
+				</connector>
+				<connector uid="164" angle="305.267">
+					<from>
+						<alias uid="28"/>
+					</from>
+					<to>gross_worker_income</to>
+				</connector>
+				<connector uid="165" angle="281.703">
+					<from>
+						<alias uid="30"/>
+					</from>
+					<to>gross_worker_income</to>
+				</connector>
+				<connector uid="166" angle="38.4455">
+					<from>gross_worker_income</from>
+					<to>net_worker_income</to>
+				</connector>
+				<aux x="932.5" y="767.5" name="gross owner income"/>
+				<connector uid="171" angle="122.8">
+					<from>gross_owner_income</from>
+					<to>net_owner_income</to>
+				</connector>
+				<connector uid="172" angle="253.471">
+					<from>
+						<alias uid="39"/>
+					</from>
+					<to>gross_owner_income</to>
+				</connector>
+				<connector uid="173" angle="235.066">
+					<from>
+						<alias uid="37"/>
+					</from>
+					<to>gross_owner_income</to>
+				</connector>
+				<connector uid="174" angle="264.399">
+					<from>
+						<alias uid="35"/>
+					</from>
+					<to>gross_owner_income</to>
+				</connector>
+				<aux x="979.433" y="513.75" name="gross income"/>
+				<connector uid="175" angle="272.322">
+					<from>
+						<alias uid="176"/>
+					</from>
+					<to>gross_income</to>
+				</connector>
+				<connector uid="177" angle="352.501">
+					<from>
+						<alias uid="178"/>
+					</from>
+					<to>gross_income</to>
+				</connector>
+				<aux x="1089.25" y="524.25" name="share of gross income from non bank profits"/>
+				<connector uid="186" angle="183.538">
+					<from>
+						<alias uid="187"/>
+					</from>
+					<to>share_of_gross_income_from_non_bank_profits</to>
+				</connector>
+				<aux x="1182.88" y="531.75" name="share of gross income from rent"/>
+				<aux x="1254.08" y="535.417" name="share of gross income from bank profits"/>
+				<aux x="1327.92" y="542.25" name="share of gross income from owner savings interest"/>
+				<aux x="1438.75" y="553.417" name="share of gross income from transfers"/>
+				<aux x="1521.25" y="553.417" name="share of gross income from worker savings\ninterest"/>
+				<aux x="1610.5" y="553.417" name="share of gross income from wages"/>
+				<connector uid="188" angle="253.666">
+					<from>
+						<alias uid="182"/>
+					</from>
+					<to>share_of_gross_income_from_non_bank_profits</to>
+				</connector>
+				<connector uid="189" angle="266.532">
+					<from>
+						<alias uid="179"/>
+					</from>
+					<to>share_of_gross_income_from_rent</to>
+				</connector>
+				<connector uid="190" angle="272.598">
+					<from>
+						<alias uid="180"/>
+					</from>
+					<to>share_of_gross_income_from_bank_profits</to>
+				</connector>
+				<connector uid="191" angle="273.691">
+					<from>
+						<alias uid="181"/>
+					</from>
+					<to>share_of_gross_income_from_owner_savings_interest</to>
+				</connector>
+				<connector uid="192" angle="270">
+					<from>
+						<alias uid="185"/>
+					</from>
+					<to>share_of_gross_income_from_transfers</to>
+				</connector>
+				<connector uid="193" angle="262.238">
+					<from>
+						<alias uid="184"/>
+					</from>
+					<to>share_of_gross_income_from_worker_savings_interest</to>
+				</connector>
+				<connector uid="194" angle="269.63">
+					<from>
+						<alias uid="183"/>
+					</from>
+					<to>share_of_gross_income_from_wages</to>
+				</connector>
+				<connector uid="195" angle="175.815">
+					<from>
+						<alias uid="187"/>
+					</from>
+					<to>share_of_gross_income_from_rent</to>
+				</connector>
+				<connector uid="196" angle="194.676">
+					<from>
+						<alias uid="187"/>
+					</from>
+					<to>share_of_gross_income_from_bank_profits</to>
+				</connector>
+				<connector uid="197" angle="220.711">
+					<from>
+						<alias uid="187"/>
+					</from>
+					<to>share_of_gross_income_from_owner_savings_interest</to>
+				</connector>
+				<connector uid="198" angle="316.909">
+					<from>
+						<alias uid="187"/>
+					</from>
+					<to>share_of_gross_income_from_transfers</to>
+				</connector>
+				<connector uid="199" angle="352.304">
+					<from>
+						<alias uid="187"/>
+					</from>
+					<to>share_of_gross_income_from_worker_savings_interest</to>
+				</connector>
+				<connector uid="200" angle="19.9831">
+					<from>
+						<alias uid="187"/>
+					</from>
+					<to>share_of_gross_income_from_wages</to>
+				</connector>
+				<aux font_style="italic" font_weight="bold" x="1496.25" y="369.583" name="inflation adjustment b$ per bc$ 1"/>
+				<aux x="1116.75" y="224.25" name="non bank profits in 2021c$"/>
+				<aux x="1207.08" y="224.25" name="rent in in 2021c$"/>
+				<aux x="1272.08" y="224.25" name="bank profits in 2021c$"/>
+				<aux x="1342.91" y="224.25" name="owner savings interest in 2021c$"/>
+				<aux x="1420.75" y="224.25" name="transfers in 2021c$"/>
+				<aux x="1507.92" y="227.917" name="worker savings interest in 2021c$"/>
+				<aux x="1592.5" y="236.25" name="wages in 2021c$"/>
+				<connector uid="202" angle="86.6499">
+					<from>
+						<alias uid="182"/>
+					</from>
+					<to>&quot;non_bank_profits_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="203" angle="84.5597">
+					<from>
+						<alias uid="179"/>
+					</from>
+					<to>&quot;rent_in_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="204" angle="83.9418">
+					<from>
+						<alias uid="180"/>
+					</from>
+					<to>&quot;bank_profits_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="205" angle="86.0091">
+					<from>
+						<alias uid="181"/>
+					</from>
+					<to>&quot;owner_savings_interest_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="206" angle="93.6914">
+					<from>
+						<alias uid="185"/>
+					</from>
+					<to>&quot;transfers_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="207" angle="94.0145">
+					<from>
+						<alias uid="184"/>
+					</from>
+					<to>&quot;worker_savings_interest_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="208" angle="103.963">
+					<from>
+						<alias uid="183"/>
+					</from>
+					<to>&quot;wages_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="209" angle="159.045">
+					<from>&quot;inflation_adjustment_b$_per_bc$_1&quot;</from>
+					<to>&quot;non_bank_profits_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="210" angle="153.316">
+					<from>&quot;inflation_adjustment_b$_per_bc$_1&quot;</from>
+					<to>&quot;rent_in_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="211" angle="107.905">
+					<from>&quot;inflation_adjustment_b$_per_bc$_1&quot;</from>
+					<to>&quot;bank_profits_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="212" angle="99.6221">
+					<from>&quot;inflation_adjustment_b$_per_bc$_1&quot;</from>
+					<to>&quot;owner_savings_interest_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="213" angle="93.9084">
+					<from>&quot;inflation_adjustment_b$_per_bc$_1&quot;</from>
+					<to>&quot;transfers_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="214" angle="48.0896">
+					<from>&quot;inflation_adjustment_b$_per_bc$_1&quot;</from>
+					<to>&quot;worker_savings_interest_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="215" angle="2.6886">
+					<from>&quot;inflation_adjustment_b$_per_bc$_1&quot;</from>
+					<to>&quot;wages_in_2021c$&quot;</to>
+				</connector>
+				<aux x="1695.5" y="242.25" name="wage tax in 2021c$"/>
+				<aux x="1776.83" y="242.25" name="rent tax in 2021c$"/>
+				<aux x="1850.25" y="242.25" name="profit tax in 2021c$"/>
+				<aux x="1936.25" y="242.25" name="net worker income in 2021c$"/>
+				<aux x="2034" y="236.25" name="net owner income in 2021c$"/>
+				<connector uid="222" angle="99.8658">
+					<from>
+						<alias uid="217"/>
+					</from>
+					<to>&quot;wage_tax_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="223" angle="83.8845">
+					<from>
+						<alias uid="218"/>
+					</from>
+					<to>&quot;rent_tax_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="224" angle="77.9885">
+					<from>
+						<alias uid="219"/>
+					</from>
+					<to>&quot;profit_tax_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="225" angle="70.71">
+					<from>
+						<alias uid="220"/>
+					</from>
+					<to>&quot;net_worker_income_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="226" angle="77.1217">
+					<from>
+						<alias uid="221"/>
+					</from>
+					<to>&quot;net_owner_income_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="227" angle="349.234">
+					<from>&quot;inflation_adjustment_b$_per_bc$_1&quot;</from>
+					<to>&quot;wage_tax_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="228" angle="24.4096">
+					<from>&quot;inflation_adjustment_b$_per_bc$_1&quot;</from>
+					<to>&quot;rent_tax_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="229" angle="4.81215">
+					<from>&quot;inflation_adjustment_b$_per_bc$_1&quot;</from>
+					<to>&quot;profit_tax_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="230" angle="348.429">
+					<from>&quot;inflation_adjustment_b$_per_bc$_1&quot;</from>
+					<to>&quot;net_worker_income_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="231" angle="357.694">
+					<from>&quot;inflation_adjustment_b$_per_bc$_1&quot;</from>
+					<to>&quot;net_owner_income_in_2021c$&quot;</to>
+				</connector>
+				<aux x="1628.5" y="135" name="wages after tax in 2021c$"/>
+				<aux x="1116.75" y="127.5" name="non bank profits\nafter tax in 2021c$"/>
+				<aux x="1272.08" y="120" name="bank profits after tax in 2021c$"/>
+				<aux x="1448.75" y="135" name="rent after tax in 2021c$"/>
+				<connector uid="234" angle="70.4269">
+					<from>&quot;wages_in_2021c$&quot;</from>
+					<to>&quot;wages_after_tax_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="235" angle="121.993">
+					<from>&quot;wage_tax_in_2021c$&quot;</from>
+					<to>&quot;wages_after_tax_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="236" angle="90">
+					<from>&quot;non_bank_profits_in_2021c$&quot;</from>
+					<to>&quot;non_bank_profits_after_tax_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="238" angle="161.897">
+					<from>&quot;rent_tax_in_2021c$&quot;</from>
+					<to>&quot;rent_after_tax_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="239" angle="20.2697">
+					<from>&quot;rent_in_in_2021c$&quot;</from>
+					<to>&quot;rent_after_tax_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="240" angle="299.991">
+					<from>
+						<alias uid="241"/>
+					</from>
+					<to>&quot;non_bank_profits_after_tax_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="242" angle="338.761">
+					<from>
+						<alias uid="241"/>
+					</from>
+					<to>&quot;bank_profits_after_tax_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="243" angle="90">
+					<from>&quot;bank_profits_in_2021c$&quot;</from>
+					<to>&quot;bank_profits_after_tax_in_2021c$&quot;</to>
+				</connector>
+				<alias label_side="top" uid="8" x="2025" y="1070.87" width="18" height="18">
 					<of>time_to_reach_savings_goal</of>
 				</alias>
-				<alias label_side="right" label_angle="45" uid="12" x="1837.58" y="184.79" width="18" height="18">
+				<alias label_side="right" label_angle="45" uid="12" x="1803.83" y="661.04" width="18" height="18">
 					<of>time_to_consider_desired_savings</of>
 				</alias>
-				<alias color="blue" background="white" font_style="italic" label_side="left" label_angle="135" uid="30" x="1573.05" y="200.79" width="18" height="18">
+				<alias color="blue" background="white" font_style="italic" label_side="left" label_angle="135" uid="30" x="1494.68" y="629.04" width="18" height="18">
 					<shape type="circle" radius="18"/>
 					<of>transfers</of>
 				</alias>
-				<alias font_style="italic" label_side="left" uid="28" x="1532" y="268.25" width="18" height="18">
+				<alias font_style="italic" label_side="left" uid="28" x="1434.25" y="665" width="18" height="18">
 					<of>worker_savings_interest</of>
 				</alias>
-				<alias font_style="italic" label_side="top" uid="49" x="1617.25" y="202.79" width="18" height="18">
+				<alias font_style="italic" label_side="top" uid="49" x="1583.5" y="679.04" width="18" height="18">
 					<of>wage_tax</of>
 				</alias>
-				<alias font_style="italic" uid="23" x="341.583" y="90.8333" width="18" height="18">
+				<alias font_style="italic" uid="23" x="307.833" y="567.083" width="18" height="18">
 					<of>owner_consumption</of>
 				</alias>
-				<alias font_style="italic" uid="25" x="399.083" y="57.1633" width="18" height="18">
+				<alias font_style="italic" uid="25" x="365.333" y="533.413" width="18" height="18">
 					<of>worker_consumption</of>
 				</alias>
-				<alias font_style="italic" label_side="left" label_angle="135" uid="35" x="896.667" y="188.75" width="18" height="18">
+				<alias font_style="italic" label_side="top" uid="35" x="934.43" y="647.04" width="18" height="18">
 					<of>rent</of>
 				</alias>
-				<alias font_style="italic" label_side="top" uid="39" x="942.584" y="184.79" width="18" height="18">
+				<alias font_style="italic" label_side="top" uid="39" x="997.67" y="647.04" width="18" height="18">
 					<of>bank_profits</of>
 				</alias>
-				<alias font_style="italic" label_side="left" uid="37" x="867.417" y="213" width="18" height="18">
+				<alias font_style="italic" label_side="right" uid="37" x="1039.25" y="661.04" width="18" height="18">
 					<of>owner_savings_interest</of>
 				</alias>
-				<alias color="blue" background="white" font_style="italic" label_side="bottom" uid="70" x="927.31" y="989.238" width="18" height="18">
+				<alias color="blue" background="white" font_style="italic" label_side="bottom" uid="70" x="893.56" y="1465.49" width="18" height="18">
 					<shape type="circle" radius="18"/>
 					<of>net_owner_income</of>
 				</alias>
-				<alias font_style="italic" label_side="left" uid="43" x="685.084" y="425.25" width="18" height="18">
+				<alias font_style="italic" label_side="left" uid="43" x="651.334" y="901.5" width="18" height="18">
 					<of>non_bank_profits</of>
 				</alias>
-				<alias font_style="italic" uid="45" x="687.209" y="628.617" width="18" height="18">
+				<alias font_style="italic" uid="45" x="653.459" y="1104.87" width="18" height="18">
 					<of>rent</of>
 				</alias>
-				<alias font_style="italic" label_side="left" uid="47" x="685.084" y="389.892" width="18" height="18">
+				<alias font_style="italic" label_side="left" uid="47" x="651.334" y="866.142" width="18" height="18">
 					<of>bank_profits</of>
 				</alias>
-				<alias font_style="italic" label_side="top" uid="17" x="1822.54" y="495.283" width="18" height="18">
+				<alias font_style="italic" label_side="top" uid="17" x="1788.79" y="971.533" width="18" height="18">
 					<of>wages</of>
 				</alias>
-				<alias font_style="italic" label_side="right" label_angle="45" uid="51" x="981.917" y="251.25" width="18" height="18">
+				<alias font_style="italic" label_side="right" label_angle="45" uid="51" x="877.583" y="611.04" width="18" height="18">
 					<of>profit_tax</of>
 				</alias>
-				<alias font_style="italic" label_side="right" label_angle="45" uid="53" x="973.25" y="212.573" width="18" height="18">
+				<alias font_style="italic" label_side="right" label_angle="45" uid="53" x="834.5" y="601.25" width="18" height="18">
 					<of>rent_tax</of>
 				</alias>
-				<alias font_style="italic" label_side="bottom" uid="81" x="1597.93" y="989.238" width="18" height="18">
+				<alias font_style="italic" label_side="bottom" uid="81" x="1564.18" y="1465.49" width="18" height="18">
 					<of>net_worker_income</of>
 				</alias>
-				<alias font_style="italic" label_side="left" uid="83" x="1518.33" y="934.238" width="18" height="18">
+				<alias font_style="italic" label_side="left" uid="83" x="1484.58" y="1410.49" width="18" height="18">
 					<of>minimum_fraction_of_income_to_consumption</of>
 				</alias>
-				<alias color="blue" background="white" font_style="italic" label_side="right" uid="88" x="1689.24" y="834" width="18" height="18">
+				<alias color="blue" background="white" font_style="italic" label_side="right" uid="88" x="1655.49" y="1310.25" width="18" height="18">
 					<shape type="circle" radius="18"/>
 					<of>consumption_habits_adjustment_time</of>
 				</alias>
-				<alias font_style="italic" label_side="right" uid="79" x="927.31" y="1041.71" width="18" height="18">
+				<alias font_style="italic" label_side="right" uid="79" x="893.56" y="1517.96" width="18" height="18">
 					<of>owner_consumption</of>
 				</alias>
-				<alias font_style="italic" uid="92" x="1597.93" y="1041.71" width="18" height="18">
+				<alias font_style="italic" uid="92" x="1564.18" y="1517.96" width="18" height="18">
 					<of>worker_consumption</of>
 				</alias>
-				<alias font_style="italic" label_side="right" uid="101" x="1689.24" y="780" width="18" height="18">
+				<alias font_style="italic" label_side="right" uid="101" x="1655.49" y="1256.25" width="18" height="18">
 					<of>inflation_effect_on_consumption</of>
 				</alias>
-				<alias font_style="italic" label_side="left" uid="106" x="798.583" y="1385" width="18" height="18">
+				<alias font_style="italic" label_side="left" uid="106" x="764.833" y="1861.25" width="18" height="18">
 					<of>owner_consumption</of>
 				</alias>
-				<alias font_style="italic" label_side="left" uid="108" x="798.583" y="1413" width="18" height="18">
+				<alias font_style="italic" label_side="left" uid="108" x="764.833" y="1889.25" width="18" height="18">
 					<of>worker_consumption</of>
 				</alias>
-				<alias font_style="italic" label_side="left" uid="110" x="798.583" y="1358" width="18" height="18">
+				<alias font_style="italic" label_side="left" uid="110" x="764.833" y="1834.25" width="18" height="18">
 					<of>private_investment</of>
 				</alias>
-				<alias font_style="italic" label_side="left" uid="112" x="798.583" y="1328" width="18" height="18">
+				<alias font_style="italic" label_side="left" uid="112" x="764.833" y="1804.25" width="18" height="18">
 					<of>government_spending</of>
 				</alias>
-				<alias font_style="italic" label_side="right" uid="114" x="1330" y="1324" width="18" height="18">
+				<alias font_style="italic" label_side="right" uid="114" x="1296.25" y="1800.25" width="18" height="18">
 					<of>non_bank_profits</of>
 				</alias>
-				<alias font_style="italic" label_side="right" uid="116" x="1330" y="1358" width="18" height="18">
+				<alias font_style="italic" label_side="right" uid="116" x="1296.25" y="1834.25" width="18" height="18">
 					<of>wages</of>
 				</alias>
-				<alias font_style="italic" label_side="right" uid="120" x="1330" y="1435" width="18" height="18">
+				<alias font_style="italic" label_side="right" uid="120" x="1296.25" y="1911.25" width="18" height="18">
 					<of>rent</of>
 				</alias>
-				<alias font_style="italic" label_side="right" uid="118" x="1330" y="1395" width="18" height="18">
+				<alias font_style="italic" label_side="right" uid="118" x="1296.25" y="1871.25" width="18" height="18">
 					<of>firms_paying_interest</of>
 				</alias>
-				<alias font_style="italic" uid="126" x="1122" y="1171" width="18" height="18">
+				<alias font_style="italic" uid="126" x="1088.25" y="1647.25" width="18" height="18">
 					<of>net_owner_income</of>
 				</alias>
-				<alias font_style="italic" uid="128" x="1237" y="1170" width="18" height="18">
+				<alias font_style="italic" uid="128" x="1203.25" y="1646.25" width="18" height="18">
 					<of>net_worker_income</of>
 				</alias>
-				<alias font_style="italic" font_weight="bold" uid="140" x="303" y="616.75" width="18" height="18">
+				<alias font_style="italic" font_weight="bold" uid="140" x="269.25" y="1093" width="18" height="18">
 					<of>start_year</of>
 				</alias>
-				<alias font_style="italic" font_weight="bold" uid="142" x="292" y="489" width="18" height="18">
+				<alias font_style="italic" font_weight="bold" uid="142" x="258.25" y="965.25" width="18" height="18">
 					<of>switch_tax_policy</of>
 				</alias>
-				<alias font_style="italic" font_weight="bold" uid="149" x="1924" y="924" width="18" height="18">
+				<alias font_style="italic" font_weight="bold" uid="149" x="1890.25" y="1400.25" width="18" height="18">
 					<of>time_to_implement_tax_policy</of>
+				</alias>
+				<alias color="blue" background="white" font_style="italic" uid="176" x="983.417" y="446.917" width="18" height="18">
+					<shape type="circle" radius="18"/>
+					<of>gross_owner_income</of>
+				</alias>
+				<alias color="blue" background="white" font_style="italic" uid="178" x="898.833" y="479.583" width="18" height="18">
+					<shape type="circle" radius="18"/>
+					<of>gross_worker_income</of>
+				</alias>
+				<alias font_style="italic" uid="179" x="1176.42" y="427.25" width="18" height="18">
+					<of>rent</of>
+				</alias>
+				<alias font_style="italic" uid="180" x="1240.58" y="427.25" width="18" height="18">
+					<of>bank_profits</of>
+				</alias>
+				<alias font_style="italic" uid="181" x="1326.42" y="426.417" width="18" height="18">
+					<of>owner_savings_interest</of>
+				</alias>
+				<alias font_style="italic" uid="182" x="1107.75" y="421.417" width="18" height="18">
+					<of>non_bank_profits</of>
+				</alias>
+				<alias font_style="italic" uid="183" x="1610.75" y="433.917" width="18" height="18">
+					<of>wages</of>
+				</alias>
+				<alias font_style="italic" uid="184" x="1539.18" y="433.917" width="18" height="18">
+					<of>worker_savings_interest</of>
+				</alias>
+				<alias font_style="italic" uid="185" x="1439.75" y="430.583" width="18" height="18">
+					<of>transfers</of>
+				</alias>
+				<alias color="blue" background="white" font_style="italic" uid="187" x="1371.42" y="497.25" width="18" height="18">
+					<shape type="circle" radius="18"/>
+					<of>gross_income</of>
+				</alias>
+				<alias font_style="italic" uid="217" x="1673.5" y="433.5" width="18" height="18">
+					<of>wage_tax</of>
+				</alias>
+				<alias font_style="italic" uid="218" x="1737.25" y="433.5" width="18" height="18">
+					<of>rent_tax</of>
+				</alias>
+				<alias font_style="italic" uid="219" x="1799.75" y="439.5" width="18" height="18">
+					<of>profit_tax</of>
+				</alias>
+				<alias font_style="italic" uid="220" x="1881" y="429.75" width="18" height="18">
+					<of>net_worker_income</of>
+				</alias>
+				<alias font_style="italic" uid="221" x="1979.75" y="425.167" width="18" height="18">
+					<of>net_owner_income</of>
+				</alias>
+				<alias font_style="italic" uid="241" x="1057.25" y="31" width="18" height="18">
+					<of>actual_profit_tax_rate</of>
 				</alias>
 			</view>
 		</views>
@@ -6544,7 +7093,7 @@ ELSE 0</eqn>
 				<isee:iframe color="black" background="white" text_align="left" vertical_text_align="top" font_size="12pt" border_width="thin" border_style="solid"/>
 				<isee:financial_table color="black" background="#E0E0E0" text_align="right" font_size="12pt" hide_border="false" auto_fit="true" first_column_width="250" other_column_width="100" header_font_style="normal" header_font_weight="bold" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="14pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 			</style>
-			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="4" isee:page_rows="3" isee:scroll_x="1445.56" isee:scroll_y="570" zoom="180" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
+			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="4" isee:page_rows="3" isee:scroll_x="85" isee:scroll_y="162.222" zoom="180" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
 				<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
 					<stock color="blue" background="white" font_color="blue" font_size="11pt" label_side="top">
 						<shape type="rectangle" width="45" height="35"/>
@@ -7581,7 +8130,7 @@ ELSE 0</eqn>
 				<dimensions>
 					<dim name="Run"/>
 				</dimensions>
-				<eqn>private_consumption_1 + Investment_1 + government_spending</eqn>
+				<eqn>private_consumption_1 + Investment_1 + Government_Spending_1</eqn>
 				<format scale_by="auto"/>
 				<units>b$/year</units>
 			</aux>
@@ -7620,7 +8169,7 @@ ELSE 0</eqn>
 				<eqn>INIT(Nominal_GDP/(initial_nominal_GDP_growth_rate*time_to_measure_GDP_growth_rate + 1))</eqn>
 				<units>b$/year</units>
 			</aux>
-			<aux name="government spending" access="input">
+			<aux name="Government Spending 1" access="input">
 				<dimensions>
 					<dim name="Run"/>
 				</dimensions>
@@ -7663,6 +8212,104 @@ ELSE 0</eqn>
 				</dimensions>
 				<eqn>{Enter equation for use when not hooked up to other models}</eqn>
 				<units>b$/bc$</units>
+			</aux>
+			<aux name="private investment" access="input">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>{Enter equation for use when not hooked up to other models}</eqn>
+				<units>b$/year</units>
+			</aux>
+			<aux name="public\ninvestment" access="input">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>{Enter equation for use when not hooked up to other models}</eqn>
+				<units>b$/year</units>
+			</aux>
+			<aux name="Nominal GDP Check">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>Private_Consumption_excluding_Government_Transfers+private_investment+Government_Spending_including_Transfers</eqn>
+				<units>b$/year</units>
+			</aux>
+			<aux name="Government Spending including Transfers">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>Government_Spending_1+public_investment+government_transfers_1</eqn>
+				<units>b$/year</units>
+			</aux>
+			<aux name="government transfers 1" access="input">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>{Enter equation for use when not hooked up to other models}</eqn>
+				<units>b$/year</units>
+			</aux>
+			<aux name="Private Consumption excluding Government Transfers">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>private_consumption_1-government_transfers_1</eqn>
+				<units>b$/year</units>
+			</aux>
+			<aux name="owner consumption" access="input">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>{Enter equation for use when not hooked up to other models}</eqn>
+				<units>b$/year</units>
+			</aux>
+			<aux name="worker consumption" access="input">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>{Enter equation for use when not hooked up to other models}</eqn>
+				<units>b$/year</units>
+			</aux>
+			<aux name="owner consumption in 2021c$">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>owner_consumption/&quot;inflation_adjustment_b$_per_bc$&quot;</eqn>
+				<units>bc$/year</units>
+			</aux>
+			<aux name="worker consumption excluding transfers in 2021c$">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>worker_consumption/&quot;inflation_adjustment_b$_per_bc$&quot;-&quot;government_transfers_in_2021c$&quot;</eqn>
+				<units>bc$/year</units>
+			</aux>
+			<aux name="government transfers\nin 2021c$">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>government_transfers_1/&quot;inflation_adjustment_b$_per_bc$&quot;</eqn>
+				<units>bc$/year</units>
+			</aux>
+			<aux name="public investment\nin 2021c$">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>public_investment/&quot;inflation_adjustment_b$_per_bc$&quot;</eqn>
+				<units>bc$/year</units>
+			</aux>
+			<aux name="private investment in\nin 2021c$">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>private_investment/&quot;inflation_adjustment_b$_per_bc$&quot;</eqn>
+				<units>bc$/year</units>
+			</aux>
+			<aux name="government consumption\nin 2021c$">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>Government_Spending_1/&quot;inflation_adjustment_b$_per_bc$&quot;</eqn>
+				<units>bc$/year</units>
 			</aux>
 		</variables>
 		<views>
@@ -7713,7 +8360,7 @@ ELSE 0</eqn>
 				<isee:iframe color="black" background="white" text_align="left" vertical_text_align="top" font_size="12pt" border_width="thin" border_style="solid"/>
 				<isee:financial_table color="black" background="#E0E0E0" text_align="right" font_size="12pt" hide_border="false" auto_fit="true" first_column_width="250" other_column_width="100" header_font_style="normal" header_font_weight="bold" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="14pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 			</style>
-			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="2" isee:page_rows="2" isee:scroll_y="106.25" zoom="160" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
+			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="2" isee:page_rows="3" isee:scroll_y="814.286" zoom="140" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
 				<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
 					<stock color="blue" background="white" font_color="blue" font_size="11pt" label_side="top">
 						<shape type="rectangle" width="45" height="35"/>
@@ -7798,9 +8445,9 @@ ELSE 0</eqn>
 					<to>initial_average_GDP</to>
 				</connector>
 				<aux label_side="top" x="363.14" y="70" name="initial nominal GDP growth rate"/>
-				<aux font_style="italic" font_weight="bold" label_side="top" x="185.07" y="125.42" name="government spending"/>
+				<aux font_style="italic" font_weight="bold" label_side="top" x="185.07" y="125.42" name="Government Spending 1"/>
 				<connector uid="12" angle="270">
-					<from>government_spending</from>
+					<from>Government_Spending_1</from>
 					<to>Nominal_GDP</to>
 				</connector>
 				<aux font_style="italic" font_weight="bold" label_side="top" x="83" y="179" name="Investment 1"/>
@@ -7836,8 +8483,151 @@ ELSE 0</eqn>
 					<from>&quot;inflation_adjustment_b$_per_bc$&quot;</from>
 					<to>&quot;Real_GDP_in_2021c$&quot;</to>
 				</connector>
+				<aux font_style="italic" font_weight="bold" x="201.25" y="643.625" name="private investment"/>
+				<aux font_style="italic" font_weight="bold" x="478.75" y="636.875" name="public\ninvestment"/>
+				<aux x="316.875" y="700.125" name="Nominal GDP Check"/>
+				<connector uid="35" angle="172.863">
+					<from>public_investment</from>
+					<to>Government_Spending_including_Transfers</to>
+				</connector>
+				<connector uid="36" angle="333.958">
+					<from>private_investment</from>
+					<to>Nominal_GDP_Check</to>
+				</connector>
+				<aux x="371.25" y="648.125" name="Government Spending including Transfers"/>
+				<connector uid="39" angle="267.33">
+					<from>
+						<alias uid="38"/>
+					</from>
+					<to>Government_Spending_including_Transfers</to>
+				</connector>
+				<connector uid="42" angle="223.721">
+					<from>Government_Spending_including_Transfers</from>
+					<to>Nominal_GDP_Check</to>
+				</connector>
+				<aux font_style="italic" font_weight="bold" x="102.5" y="809.375" name="government transfers 1"/>
+				<aux x="134.125" y="725.125" name="Private Consumption excluding Government Transfers"/>
+				<connector uid="43" angle="320.765">
+					<from>
+						<alias uid="44"/>
+					</from>
+					<to>Private_Consumption_excluding_Government_Transfers</to>
+				</connector>
+				<connector uid="45" angle="98.5331">
+					<from>government_transfers_1</from>
+					<to>Private_Consumption_excluding_Government_Transfers</to>
+				</connector>
+				<connector uid="46" angle="326.031">
+					<from>Private_Consumption_excluding_Government_Transfers</from>
+					<to>Nominal_GDP_Check</to>
+				</connector>
+				<connector uid="47" angle="328.449">
+					<from>government_transfers_1</from>
+					<to>Government_Spending_including_Transfers</to>
+				</connector>
+				<aux font_style="italic" font_weight="bold" label_side="bottom" x="83.75" y="910.625" name="owner consumption"/>
+				<aux font_style="italic" font_weight="bold" x="246.25" y="903.75" name="worker consumption"/>
+				<aux x="74.2857" y="1145" name="owner consumption in 2021c$"/>
+				<aux x="249.286" y="1145" name="worker consumption excluding transfers in 2021c$"/>
+				<aux x="410.714" y="1140" name="government transfers\nin 2021c$"/>
+				<aux x="517.857" y="1140" name="public investment\nin 2021c$"/>
+				<aux x="621.661" y="1140" name="private investment in\nin 2021c$"/>
+				<aux x="739.286" y="1136.43" name="government consumption\nin 2021c$"/>
+				<connector uid="53" angle="268.542">
+					<from>owner_consumption</from>
+					<to>&quot;owner_consumption_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="54" angle="274.154">
+					<from>worker_consumption</from>
+					<to>&quot;worker_consumption_excluding_transfers_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="55" angle="283.891">
+					<from>
+						<alias uid="48"/>
+					</from>
+					<to>&quot;government_transfers_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="56" angle="283.264">
+					<from>
+						<alias uid="50"/>
+					</from>
+					<to>&quot;public_investment_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="57" angle="292.109">
+					<from>
+						<alias uid="49"/>
+					</from>
+					<to>&quot;private_investment_in_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="58" angle="304.657">
+					<from>
+						<alias uid="51"/>
+					</from>
+					<to>&quot;government_consumption_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="59" angle="208.301">
+					<from>
+						<alias uid="52"/>
+					</from>
+					<to>&quot;owner_consumption_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="60" angle="230.572">
+					<from>
+						<alias uid="52"/>
+					</from>
+					<to>&quot;worker_consumption_excluding_transfers_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="61" angle="281.07">
+					<from>
+						<alias uid="52"/>
+					</from>
+					<to>&quot;government_transfers_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="62" angle="320.711">
+					<from>
+						<alias uid="52"/>
+					</from>
+					<to>&quot;public_investment_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="63" angle="331.144">
+					<from>
+						<alias uid="52"/>
+					</from>
+					<to>&quot;private_investment_in_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="64" angle="357.709">
+					<from>
+						<alias uid="52"/>
+					</from>
+					<to>&quot;government_consumption_in_2021c$&quot;</to>
+				</connector>
+				<connector uid="65" angle="182.49">
+					<from>&quot;government_transfers_in_2021c$&quot;</from>
+					<to>&quot;worker_consumption_excluding_transfers_in_2021c$&quot;</to>
+				</connector>
 				<alias font_style="italic" label_side="top" uid="9" x="442.67" y="85" width="18" height="18">
 					<of>Nominal_GDP</of>
+				</alias>
+				<alias font_style="italic" font_weight="bold" uid="38" x="386.625" y="549.125" width="18" height="18">
+					<of>Government_Spending_1</of>
+				</alias>
+				<alias font_style="italic" font_weight="bold" uid="44" x="52.875" y="657.125" width="18" height="18">
+					<of>private_consumption_1</of>
+				</alias>
+				<alias font_style="italic" font_weight="bold" uid="48" x="350.768" y="894.75" width="18" height="18">
+					<of>government_transfers_1</of>
+				</alias>
+				<alias font_style="italic" font_weight="bold" uid="49" x="567.25" y="891" width="18" height="18">
+					<of>private_investment</of>
+				</alias>
+				<alias font_style="italic" font_weight="bold" uid="50" x="470.375" y="897.875" width="18" height="18">
+					<of>public_investment</of>
+				</alias>
+				<alias font_style="italic" font_weight="bold" uid="51" x="680.375" y="891" width="18" height="18">
+					<of>Government_Spending_1</of>
+				</alias>
+				<alias font_style="italic" font_weight="bold" uid="52" x="401.714" y="1039.57" width="18" height="18">
+					<of>&quot;inflation_adjustment_b$_per_bc$&quot;</of>
 				</alias>
 			</view>
 		</views>
@@ -8822,7 +9612,7 @@ https://www.oecd-ilibrary.org/sites/e2ee1eb1-en/index.html?itemId=/content/compo
 				<isee:iframe color="black" background="white" text_align="left" vertical_text_align="top" font_size="12pt" border_width="thin" border_style="solid"/>
 				<isee:financial_table color="black" background="#E0E0E0" text_align="right" font_size="12pt" hide_border="false" auto_fit="true" first_column_width="250" other_column_width="100" header_font_style="normal" header_font_weight="bold" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="14pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 			</style>
-			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="3" isee:page_rows="4" isee:scroll_y="300" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
+			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="3" isee:page_rows="4" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
 				<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
 					<stock color="blue" background="white" font_color="blue" font_size="11pt" label_side="top">
 						<shape type="rectangle" width="45" height="35"/>
@@ -9668,8 +10458,8 @@ https://www.oecd-ilibrary.org/sites/e2ee1eb1-en/index.html?itemId=/content/compo
 					<from>climate_adjusted_public_consumption_to_transfers_ratio</from>
 					<to>government_transfers</to>
 				</connector>
-				<aux x="96" y="858" name="UNIT p per mp"/>
-				<connector uid="253" angle="53.9726">
+				<aux x="70" y="703.429" name="UNIT p per mp"/>
+				<connector uid="253" angle="14.7271">
 					<from>UNIT_p_per_mp</from>
 					<to>transfer_payments_per_recipient</to>
 				</connector>
@@ -10297,7 +11087,7 @@ agriculture_share_of_GDP_starting_point_determinant*EXP(agriculture_share_of_GDP
 				<isee:iframe color="black" background="white" text_align="left" vertical_text_align="top" font_size="12pt" border_width="thin" border_style="solid"/>
 				<isee:financial_table color="black" background="#E0E0E0" text_align="right" font_size="12pt" hide_border="false" auto_fit="true" first_column_width="250" other_column_width="100" header_font_style="normal" header_font_weight="bold" header_text_decoration="none" header_text_align="center" header_vertical_text_align="center" header_font_color="black" header_font_family="Arial" header_font_size="14pt" header_text_padding="2" header_text_border_color="black" header_text_border_width="thin" header_text_border_style="none"/>
 			</style>
-			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="3" isee:page_rows="3" isee:scroll_x="342" isee:scroll_y="468" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
+			<view isee:show_pages="false" background="white" page_width="768" page_height="588" isee:page_cols="3" isee:page_rows="3" isee:scroll_x="459" isee:scroll_y="370" isee:popup_graphs_are_comparative="true" isee:enable_non_negative_highlights="false" type="stock_flow">
 				<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
 					<stock color="blue" background="white" font_color="blue" font_size="11pt" label_side="top">
 						<shape type="rectangle" width="45" height="35"/>

--- a/FRIDA_Modules/Land Use and Agriculture.itmx
+++ b/FRIDA_Modules/Land Use and Agriculture.itmx
@@ -1811,6 +1811,13 @@ average_animal_product_growth_efficiency</eqn>
 				<eqn>feed_production/animal_products_production</eqn>
 				<units>dmnl</units>
 			</aux>
+			<aux name="calories consumed by animals not transferred to humans">
+				<dimensions>
+					<dim name="Run"/>
+				</dimensions>
+				<eqn>feed_production-animal_products_production</eqn>
+				<units>PCal/Year</units>
+			</aux>
 		</variables>
 		<views>
 			<style color="black" background="white" font_style="normal" font_weight="normal" text_decoration="none" text_align="center" vertical_text_align="center" font_color="black" font_family="Arial" font_size="10pt" padding="2" border_color="black" border_width="thin" border_style="none">
@@ -2056,6 +2063,15 @@ average_animal_product_growth_efficiency</eqn>
 						<alias uid="36"/>
 					</from>
 					<to>feed_per_unit_of_animal_product_production</to>
+				</connector>
+				<aux x="1050" y="169" name="calories consumed by animals not transferred to humans"/>
+				<connector uid="37" angle="69.3268">
+					<from>animal_products_production</from>
+					<to>calories_consumed_by_animals_not_transferred_to_humans</to>
+				</connector>
+				<connector uid="38" angle="102.903">
+					<from>feed_production</from>
+					<to>calories_consumed_by_animals_not_transferred_to_humans</to>
 				</connector>
 				<alias font_style="italic" uid="34" x="151" y="257" width="18" height="18">
 					<of>feed_production</of>


### PR DESCRIPTION
This is builds on top of the changes to goverment debt interest rates. 

This adds in a new climate feedback which says as STA rises (and therefore extreme events, and all of the other shifts in the environment for doing business) goverment allocates more of their budget to investment (i.e. repairs and mitigation for the impacts of climate change).  The intention with this feedback is to represent the tradeoffs of government spending on investment for climate mitigation purposes vs. other uses of government spending including transfer payments, and consumption.